### PR TITLE
Add impact dashboard workflow and static site

### DIFF
--- a/.github/workflows/impact-dashboard.yml
+++ b/.github/workflows/impact-dashboard.yml
@@ -6,7 +6,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write  # Required to push to gh-pages
+  contents: write   # Required to push to gh-pages
+  packages: read    # For GHCR container package enumeration (best effort)
 
 concurrency:
   group: impact-dashboard

--- a/.github/workflows/impact-dashboard.yml
+++ b/.github/workflows/impact-dashboard.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v5.1.0
 
       - name: Checkout existing gh-pages (best effort)
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v5.1.0
         with:
           ref: gh-pages
           path: gh-pages
@@ -38,7 +38,7 @@ jobs:
           fi
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.0.0
         with:
           python-version: '3.12'
 
@@ -54,7 +54,7 @@ jobs:
         run: python scripts/collect_impact.py
 
       - name: Publish to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e  # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build

--- a/.github/workflows/impact-dashboard.yml
+++ b/.github/workflows/impact-dashboard.yml
@@ -1,0 +1,64 @@
+name: Impact Dashboard
+
+on:
+  schedule:
+    - cron: '0 3 * * *'  # Daily at 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write  # Required to push to gh-pages
+
+concurrency:
+  group: impact-dashboard
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+
+      - name: Checkout existing gh-pages (best effort)
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
+        continue-on-error: true
+
+      - name: Seed build dir with previous snapshots and history
+        run: |
+          mkdir -p build
+          if [ -d gh-pages/data ]; then
+            cp -r gh-pages/data build/
+            echo "Seeded build/ with $(find build/data -type f | wc -l) existing files."
+          else
+            echo "No previous gh-pages data — starting fresh."
+          fi
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Collect impact metrics
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMPACT_DASHBOARD_PAT: ${{ secrets.IMPACT_DASHBOARD_PAT }}
+          ORG_NAME: netresearch
+          OUTPUT_DIR: build
+        run: python scripts/collect_impact.py
+
+      - name: Publish to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build
+          publish_branch: gh-pages
+          keep_files: true
+          commit_message: 'chore(dashboard): update impact metrics'
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+build/
+state/

--- a/README.md
+++ b/README.md
@@ -32,6 +32,71 @@ Monitors all public repositories in the netresearch organization for new stars a
 
 The first run indexes existing stars without sending notifications to avoid spam.
 
+### Impact Dashboard
+
+**File:** `.github/workflows/impact-dashboard.yml`
+
+Collects community-impact metrics for all non-archived `t3x-*` (TYPO3 extensions)
+and `*-skill` (Agent Skills) repositories in the org, renders a static dashboard,
+and publishes it to the `gh-pages` branch.
+
+**Schedule:** Daily at 03:00 UTC
+
+**Manual trigger:** Yes (via Actions tab → "Run workflow")
+
+**URL:** `https://netresearch.github.io/maint/` (once GitHub Pages is enabled on the `gh-pages` branch).
+
+#### What gets collected
+
+Per repo — lifetime and last 30 days where meaningful:
+
+- Metadata: language, license, topics, homepage, created/updated timestamps
+- Stars, forks, watchers, network count
+- Issues (open / closed, opened in 30d)
+- Pull requests (open / merged / closed-unmerged, opened and merged in 30d)
+- Releases (count, latest release, total asset downloads)
+- Contributors (total, external = not in public org members, top 10)
+- Commits (lifetime on default branch, last 30 days)
+- Packagist downloads (total / monthly / daily) for PHP repos with a `composer.json`
+- Traffic (clones, views, top referrers, top paths) — **last 14 days only**, requires PAT
+
+Aggregate totals and 90 days of daily snapshots feed the time-series charts.
+
+#### What is deliberately not collected
+
+- **Dependents**: GitHub exposes no API for `/network/dependents`. Skipped.
+- **GHCR container pulls**: no public download counter.
+- **TER downloads (extensions.typo3.org)**: no stable public API; Packagist stats are a reasonable proxy for TYPO3 extensions installed via composer.
+
+#### Secrets
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `GITHUB_TOKEN` | Automatic | Provided by Actions; covers all core metrics. |
+| `IMPACT_DASHBOARD_PAT` | Optional | Classic PAT with `repo` scope **or** fine-grained token with `Administration: Read` on the target repos. Required for traffic (clones/views/referrers). Without it, the dashboard shows core metrics only and flags "traffic disabled". |
+
+#### One-time setup
+
+1. **Add the PAT secret** (optional but recommended for traffic):
+   - Create a PAT at <https://github.com/settings/tokens> with `repo` scope, or a fine-grained token on the `netresearch` org with `Administration: Read` on the relevant repos.
+   - Add as `IMPACT_DASHBOARD_PAT` under Settings → Secrets → Actions in this repo.
+2. **Run the workflow once manually** (Actions tab → Impact Dashboard → Run workflow). This creates the `gh-pages` branch and the first snapshot.
+3. **Enable GitHub Pages**: Settings → Pages → Source = "Deploy from a branch", Branch = `gh-pages`, Path = `/ (root)`.
+4. **Lifetime traffic**: GitHub's traffic API only returns the trailing 14 days. A lifetime total is therefore only as old as the first successful run — the pipeline accumulates it via daily snapshots going forward.
+
+#### How the "blast radius" score is computed
+
+A coarse single-number community-participation indicator, per repo:
+
+```
+blast_radius = external_contributors × 3
+             + total_issues
+             + prs_merged
+             + forks × 2
+```
+
+Weighted toward outside-the-org involvement. Compare repos relative to each other; absolute values are not meaningful on their own.
+
 ## Adding New Automation Tasks
 
 1. Create workflow in `.github/workflows/`

--- a/README.md
+++ b/README.md
@@ -58,22 +58,29 @@ Per repo — lifetime and last 30 days where meaningful:
 - Contributors (total, external = not in public org members, top 10)
 - Commits (lifetime on default branch, last 30 days)
 - Packagist downloads (total / monthly / daily) for PHP repos with a `composer.json`
+- GHCR container pulls (lifetime total + last 30 days, exact numbers) — scraped from the package page (`<h3 title="N">` and the 30-day sparkline's `data-merge-count` bars)
+- Dependents count ("Used by N repositories / N packages") — scraped from `/network/dependents`
 - Traffic (clones, views, top referrers, top paths) — **last 14 days only**, requires PAT
 
 Aggregate totals and 90 days of daily snapshots feed the time-series charts.
 
-#### What is deliberately not collected
+#### Scraped (no stable API)
 
-- **Dependents**: GitHub exposes no API for `/network/dependents`. Skipped.
-- **GHCR container pulls**: no public download counter.
-- **TER downloads (extensions.typo3.org)**: no stable public API; Packagist stats are a reasonable proxy for TYPO3 extensions installed via composer.
+Two metrics rely on HTML scraping of `github.com` — they work today but may break if GitHub changes the DOM:
+
+- **GHCR pulls** — `github.com/<org>/<repo>/pkgs/container/<pkg>` exposes the exact count in a `title` attribute and the 30-day bars as `data-merge-count`. Package name is discovered via `GET /orgs/<org>/packages` (requires `read:packages`) or falls back to assuming `package == repo` name.
+- **Dependents** — `github.com/<org>/<repo>/network/dependents` shows `"N Repositories"` / `"N Packages"` under toggles filtered by `dependent_type`.
+
+Not collected:
+
+- **TER downloads (extensions.typo3.org)** — no stable public API; Packagist stats are a reasonable proxy for TYPO3 extensions installed via composer.
 
 #### Secrets
 
 | Secret | Required | Description |
 |--------|----------|-------------|
 | `GITHUB_TOKEN` | Automatic | Provided by Actions; covers all core metrics. |
-| `IMPACT_DASHBOARD_PAT` | Optional | Classic PAT with `repo` scope **or** fine-grained token with `Administration: Read` on the target repos. Required for traffic (clones/views/referrers). Without it, the dashboard shows core metrics only and flags "traffic disabled". |
+| `IMPACT_DASHBOARD_PAT` | Optional | Fine-grained PAT on the `netresearch` org with `Administration: Read` (for traffic) and optionally `Packages: Read` (to enumerate GHCR packages exactly instead of falling back to name-based probing). Or a classic PAT with `repo` + `read:packages` scopes. Without this secret, traffic is omitted; GHCR still works for repos whose container package name matches the repo name. |
 
 #### One-time setup
 
@@ -93,6 +100,7 @@ blast_radius = external_contributors × 3
              + total_issues
              + prs_merged
              + forks × 2
+             + dependents_repos × 2
 ```
 
 Weighted toward outside-the-org involvement. Compare repos relative to each other; absolute values are not meaningful on their own.

--- a/dashboard/assets/dashboard.js
+++ b/dashboard/assets/dashboard.js
@@ -1,0 +1,281 @@
+(() => {
+  'use strict';
+
+  const state = { scope: 'lifetime', snapshot: null, history: null, sortKey: 'stars', sortDir: -1 };
+
+  const KPI_FIELDS = {
+    lifetime: [
+      ['stars', 'Stars'],
+      ['forks', 'Forks'],
+      ['contributors', 'Contributors'],
+      ['external_contributors', 'External contrib.'],
+      ['issues_closed', 'Issues closed'],
+      ['prs_merged', 'PRs merged'],
+      ['releases', 'Releases'],
+      ['commits', 'Commits'],
+      ['packagist_downloads', 'Packagist DL'],
+    ],
+    recent_30d: [
+      ['commits_30d', 'Commits'],
+      ['issues_opened_30d', 'Issues opened'],
+      ['prs_opened_30d', 'PRs opened'],
+      ['prs_merged_30d', 'PRs merged'],
+      ['releases_30d', 'Releases'],
+      ['packagist_downloads_30d', 'Packagist DL'],
+    ],
+  };
+
+  const nf = new Intl.NumberFormat('en');
+
+  function fmt(n) { return (n === null || n === undefined) ? '—' : nf.format(n); }
+
+  async function loadJSON(path) {
+    const res = await fetch(path, { cache: 'no-cache' });
+    if (!res.ok) throw new Error(`failed to load ${path}: ${res.status}`);
+    return res.json();
+  }
+
+  async function init() {
+    try {
+      const [snapshot, history] = await Promise.all([
+        loadJSON('data/latest.json'),
+        loadJSON('data/history.json').catch(() => ({ daily: [] })),
+      ]);
+      state.snapshot = snapshot;
+      state.history = history;
+    } catch (err) {
+      document.getElementById('meta').textContent = 'Failed to load data: ' + err.message;
+      return;
+    }
+
+    renderMeta();
+    renderKPIs();
+    renderCategoryCards();
+    renderCharts();
+    renderTable();
+    attachHandlers();
+  }
+
+  function renderMeta() {
+    const s = state.snapshot;
+    const ts = new Date(s.generated_at).toLocaleString();
+    const traffic = s.traffic_available ? 'traffic enabled' : 'traffic disabled (no PAT)';
+    document.getElementById('meta').textContent =
+      `${s.repos.length} repos · last updated ${ts} · ${traffic}`;
+  }
+
+  function renderKPIs() {
+    const totals = state.snapshot.totals;
+    const fields = KPI_FIELDS[state.scope];
+    const el = document.getElementById('kpis');
+    el.innerHTML = fields.map(([key, label]) => `
+      <div class="kpi">
+        <div class="kpi-label">${label}</div>
+        <div class="kpi-value">${fmt(totals[key] ?? 0)}</div>
+      </div>`).join('');
+  }
+
+  function renderCategoryCards() {
+    const t3x = state.snapshot.repos.filter(r => r.category === 'typo3-extension');
+    const skills = state.snapshot.repos.filter(r => r.category === 'skill');
+
+    function card(title, cls, repos) {
+      const sum = (path) => repos.reduce((acc, r) => acc + (r[path[0]]?.[path[1]] ?? 0), 0);
+      return `
+        <div class="card">
+          <h3><span class="pill ${cls}">${title}</span> · ${repos.length} repos</h3>
+          <div class="stat"><span>Stars</span><span>${fmt(sum(['lifetime', 'stars']))}</span></div>
+          <div class="stat"><span>Forks</span><span>${fmt(sum(['lifetime', 'forks']))}</span></div>
+          <div class="stat"><span>Contributors</span><span>${fmt(sum(['lifetime', 'contributors']))}</span></div>
+          <div class="stat"><span>External contrib.</span><span>${fmt(sum(['lifetime', 'external_contributors']))}</span></div>
+          <div class="stat"><span>Releases</span><span>${fmt(sum(['lifetime', 'releases']))}</span></div>
+          <div class="stat"><span>Packagist DL</span><span>${fmt(sum(['lifetime', 'packagist_downloads']))}</span></div>
+          <div class="stat"><span>Commits (30d)</span><span>${fmt(sum(['recent_30d', 'commits']))}</span></div>
+        </div>`;
+    }
+
+    document.getElementById('category-cards').innerHTML =
+      card('TYPO3 extensions', 'typo3', t3x) + card('Skills', 'skill', skills);
+  }
+
+  function renderCharts() {
+    const daily = (state.history.daily || []).slice(-90);
+    const labels = daily.map(d => d.date);
+
+    const ctxStars = document.getElementById('chart-stars');
+    if (ctxStars && window.Chart) {
+      new Chart(ctxStars, {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            { label: 'Stars', data: daily.map(d => d.totals?.stars ?? 0), borderColor: '#2F99A4', tension: 0.2 },
+            { label: 'Forks', data: daily.map(d => d.totals?.forks ?? 0), borderColor: '#FF4D00', tension: 0.2 },
+            { label: 'Contributors', data: daily.map(d => d.totals?.contributors ?? 0), borderColor: '#9aa0a6', tension: 0.2 },
+          ],
+        },
+        options: chartOptions('Cumulative stars / forks / contributors (90 days)'),
+      });
+    }
+
+    const ctxAct = document.getElementById('chart-activity');
+    if (ctxAct && window.Chart) {
+      new Chart(ctxAct, {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [
+            { label: 'Commits (30d trailing)', data: daily.map(d => d.totals?.commits_30d ?? 0), backgroundColor: '#2F99A4' },
+            { label: 'PRs merged (30d)', data: daily.map(d => d.totals?.prs_merged_30d ?? 0), backgroundColor: '#FF4D00' },
+            { label: 'Releases (30d)', data: daily.map(d => d.totals?.releases_30d ?? 0), backgroundColor: '#9aa0a6' },
+          ],
+        },
+        options: chartOptions('Activity (30-day trailing totals, sampled daily)'),
+      });
+    }
+  }
+
+  function chartOptions(title) {
+    return {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        title: { display: true, text: title, color: '#e8eaed' },
+        legend: { labels: { color: '#e8eaed' } },
+      },
+      scales: {
+        x: { ticks: { color: '#9aa0a6' }, grid: { color: '#2a2f38' } },
+        y: { ticks: { color: '#9aa0a6' }, grid: { color: '#2a2f38' }, beginAtZero: true },
+      },
+    };
+  }
+
+  function renderTable() {
+    const tbody = document.querySelector('#repo-table tbody');
+    const filter = document.getElementById('repo-filter').value.toLowerCase();
+    const showT3x = document.getElementById('filter-t3x').checked;
+    const showSkill = document.getElementById('filter-skill').checked;
+
+    let rows = state.snapshot.repos.filter(r => {
+      if (r.category === 'typo3-extension' && !showT3x) return false;
+      if (r.category === 'skill' && !showSkill) return false;
+      if (filter && !r.name.toLowerCase().includes(filter) && !(r.description || '').toLowerCase().includes(filter)) return false;
+      return true;
+    });
+
+    rows.sort((a, b) => {
+      const k = state.sortKey;
+      let va, vb;
+      if (k === 'name' || k === 'language') {
+        va = (a[k] || '').toString(); vb = (b[k] || '').toString();
+        return state.sortDir * va.localeCompare(vb);
+      }
+      if (k === 'commits_30d') { va = a.recent_30d?.commits ?? 0; vb = b.recent_30d?.commits ?? 0; }
+      else if (k === 'blast_radius') { va = a.blast_radius ?? 0; vb = b.blast_radius ?? 0; }
+      else { va = a.lifetime?.[k] ?? 0; vb = b.lifetime?.[k] ?? 0; }
+      return state.sortDir * (va - vb);
+    });
+
+    tbody.innerHTML = rows.map(r => `
+      <tr data-name="${r.name}">
+        <td>
+          <a href="${r.url}" target="_blank" rel="noopener">${r.name}</a>
+          <span class="pill ${r.category === 'typo3-extension' ? 'typo3' : 'skill'}">${r.category === 'typo3-extension' ? 'TYPO3' : 'Skill'}</span>
+        </td>
+        <td>${r.language || '—'}</td>
+        <td class="num">${fmt(r.lifetime.stars)}</td>
+        <td class="num">${fmt(r.lifetime.forks)}</td>
+        <td class="num">${fmt(r.lifetime.contributors)}</td>
+        <td class="num">${fmt(r.lifetime.external_contributors)}</td>
+        <td class="num">${fmt(r.lifetime.issues_open)}</td>
+        <td class="num">${fmt(r.lifetime.prs_merged)}</td>
+        <td class="num">${fmt(r.lifetime.releases)}</td>
+        <td class="num">${fmt(r.recent_30d.commits)}</td>
+        <td class="num">${fmt(r.lifetime.packagist_downloads)}</td>
+        <td class="num">${fmt(r.blast_radius)}</td>
+      </tr>`).join('');
+  }
+
+  function renderDetail(name) {
+    const r = state.snapshot.repos.find(x => x.name === name);
+    if (!r) return;
+    const panel = document.getElementById('repo-detail');
+    document.getElementById('detail-title').innerHTML =
+      `<a href="${r.url}" target="_blank" rel="noopener">${r.full_name}</a>`;
+
+    const traffic = r.traffic_14d;
+    const trafficBlock = traffic ? `
+      <div class="card">
+        <h4>Traffic (last 14 days)</h4>
+        <div class="stat"><span>Views (total / unique)</span><span>${fmt(traffic.views_total)} / ${fmt(traffic.views_unique)}</span></div>
+        <div class="stat"><span>Clones (total / unique)</span><span>${fmt(traffic.clones_total)} / ${fmt(traffic.clones_unique)}</span></div>
+        <div class="stat"><span>Top referrers</span><span></span></div>
+        <ul class="referrer-list">${(traffic.top_referrers || []).map(rf => `<li>${rf.referrer}: ${fmt(rf.count)} views / ${fmt(rf.uniques)} unique</li>`).join('')}</ul>
+      </div>` : '<div class="card"><h4>Traffic</h4><p>Traffic data not available (requires PAT with repo scope).</p></div>';
+
+    const packagist = r.packagist ? `
+      <div class="card">
+        <h4>Packagist</h4>
+        <div class="stat"><span>Total downloads</span><span>${fmt(r.packagist.total)}</span></div>
+        <div class="stat"><span>Monthly</span><span>${fmt(r.packagist.monthly)}</span></div>
+        <div class="stat"><span>Daily</span><span>${fmt(r.packagist.daily)}</span></div>
+        <p><a href="${r.packagist.url}" target="_blank" rel="noopener">${r.packagist.name}</a></p>
+      </div>` : '';
+
+    const contributors = `
+      <div class="card">
+        <h4>Top contributors</h4>
+        ${(r.top_contributors || []).map(c => `<div class="stat"><span><a href="${c.url}" target="_blank" rel="noopener">${c.login}</a></span><span>${fmt(c.contributions)}</span></div>`).join('')}
+      </div>`;
+
+    const release = r.latest_release ? `
+      <div class="card">
+        <h4>Latest release</h4>
+        <div class="stat"><span>Tag</span><span><a href="${r.latest_release.url}" target="_blank" rel="noopener">${r.latest_release.tag_name}</a></span></div>
+        <div class="stat"><span>Published</span><span>${r.latest_release.published_at ? new Date(r.latest_release.published_at).toLocaleDateString() : '—'}</span></div>
+        <div class="stat"><span>Release downloads (total)</span><span>${fmt(r.lifetime.release_downloads)}</span></div>
+      </div>` : '';
+
+    document.getElementById('detail-body').innerHTML = `
+      <p>${r.description || ''}</p>
+      <div class="detail-grid">
+        ${contributors}
+        ${release}
+        ${packagist}
+        ${trafficBlock}
+      </div>`;
+    panel.hidden = false;
+    panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  function attachHandlers() {
+    document.querySelectorAll('.toggle').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.toggle').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        state.scope = btn.dataset.scope;
+        renderKPIs();
+      });
+    });
+
+    document.querySelectorAll('#repo-table th[data-sort]').forEach(th => {
+      th.addEventListener('click', () => {
+        const key = th.dataset.sort;
+        state.sortDir = (state.sortKey === key) ? -state.sortDir : -1;
+        state.sortKey = key;
+        renderTable();
+      });
+    });
+
+    document.getElementById('repo-filter').addEventListener('input', renderTable);
+    document.getElementById('filter-t3x').addEventListener('change', renderTable);
+    document.getElementById('filter-skill').addEventListener('change', renderTable);
+
+    document.querySelector('#repo-table tbody').addEventListener('click', (e) => {
+      const tr = e.target.closest('tr[data-name]');
+      if (tr) renderDetail(tr.dataset.name);
+    });
+  }
+
+  init();
+})();

--- a/dashboard/assets/dashboard.js
+++ b/dashboard/assets/dashboard.js
@@ -32,6 +32,11 @@
 
   function fmt(n) { return (n === null || n === undefined) ? '—' : nf.format(n); }
 
+  const ESC_MAP = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+  function esc(s) {
+    return String(s ?? '').replace(/[&<>"']/g, c => ESC_MAP[c]);
+  }
+
   async function loadJSON(path) {
     const res = await fetch(path, { cache: 'no-cache' });
     if (!res.ok) throw new Error(`failed to load ${path}: ${res.status}`);
@@ -183,12 +188,12 @@
     });
 
     tbody.innerHTML = rows.map(r => `
-      <tr data-name="${r.name}">
+      <tr data-name="${esc(r.name)}">
         <td>
-          <a href="${r.url}" target="_blank" rel="noopener">${r.name}</a>
+          <a href="${esc(r.url)}" target="_blank" rel="noopener">${esc(r.name)}</a>
           <span class="pill ${r.category === 'typo3-extension' ? 'typo3' : 'skill'}">${r.category === 'typo3-extension' ? 'TYPO3' : 'Skill'}</span>
         </td>
-        <td>${r.language || '—'}</td>
+        <td>${esc(r.language || '—')}</td>
         <td class="num">${fmt(r.lifetime.stars)}</td>
         <td class="num">${fmt(r.lifetime.forks)}</td>
         <td class="num">${fmt(r.lifetime.contributors)}</td>
@@ -209,7 +214,7 @@
     if (!r) return;
     const panel = document.getElementById('repo-detail');
     document.getElementById('detail-title').innerHTML =
-      `<a href="${r.url}" target="_blank" rel="noopener">${r.full_name}</a>`;
+      `<a href="${esc(r.url)}" target="_blank" rel="noopener">${esc(r.full_name)}</a>`;
 
     const traffic = r.traffic_14d;
     const trafficBlock = traffic ? `
@@ -218,7 +223,7 @@
         <div class="stat"><span>Views (total / unique)</span><span>${fmt(traffic.views_total)} / ${fmt(traffic.views_unique)}</span></div>
         <div class="stat"><span>Clones (total / unique)</span><span>${fmt(traffic.clones_total)} / ${fmt(traffic.clones_unique)}</span></div>
         <div class="stat"><span>Top referrers</span><span></span></div>
-        <ul class="referrer-list">${(traffic.top_referrers || []).map(rf => `<li>${rf.referrer}: ${fmt(rf.count)} views / ${fmt(rf.uniques)} unique</li>`).join('')}</ul>
+        <ul class="referrer-list">${(traffic.top_referrers || []).map(rf => `<li>${esc(rf.referrer)}: ${fmt(rf.count)} views / ${fmt(rf.uniques)} unique</li>`).join('')}</ul>
       </div>` : '<div class="card"><h4>Traffic</h4><p>Traffic data not available (requires PAT with repo scope).</p></div>';
 
     const packagist = r.packagist ? `
@@ -227,7 +232,7 @@
         <div class="stat"><span>Total downloads</span><span>${fmt(r.packagist.total)}</span></div>
         <div class="stat"><span>Monthly</span><span>${fmt(r.packagist.monthly)}</span></div>
         <div class="stat"><span>Daily</span><span>${fmt(r.packagist.daily)}</span></div>
-        <p><a href="${r.packagist.url}" target="_blank" rel="noopener">${r.packagist.name}</a></p>
+        <p><a href="${esc(r.packagist.url)}" target="_blank" rel="noopener">${esc(r.packagist.name)}</a></p>
       </div>` : '';
 
     const ghcr = r.ghcr ? `
@@ -235,7 +240,7 @@
         <h4>GHCR pulls</h4>
         <div class="stat"><span>Total (lifetime)</span><span>${fmt(r.ghcr.total)}</span></div>
         <div class="stat"><span>Last 30 days</span><span>${fmt(r.ghcr.thirty_day)}</span></div>
-        ${r.ghcr.packages.map(p => `<p><a href="${p.url}" target="_blank" rel="noopener">${p.package}</a>: ${fmt(p.total)} total / ${fmt(p.thirty_day)} 30d</p>`).join('')}
+        ${r.ghcr.packages.map(p => `<p><a href="${esc(p.url)}" target="_blank" rel="noopener">${esc(p.package)}</a>: ${fmt(p.total)} total / ${fmt(p.thirty_day)} 30d</p>`).join('')}
       </div>` : '';
 
     const dependents = r.dependents ? `
@@ -243,25 +248,25 @@
         <h4>Used by (dependents)</h4>
         <div class="stat"><span>Repositories</span><span>${fmt(r.dependents.repositories)}</span></div>
         <div class="stat"><span>Packages</span><span>${fmt(r.dependents.packages)}</span></div>
-        <p><a href="${r.dependents.url}" target="_blank" rel="noopener">View dependents graph →</a></p>
+        <p><a href="${esc(r.dependents.url)}" target="_blank" rel="noopener">View dependents graph →</a></p>
       </div>` : '';
 
     const contributors = `
       <div class="card">
         <h4>Top contributors</h4>
-        ${(r.top_contributors || []).map(c => `<div class="stat"><span><a href="${c.url}" target="_blank" rel="noopener">${c.login}</a></span><span>${fmt(c.contributions)}</span></div>`).join('')}
+        ${(r.top_contributors || []).map(c => `<div class="stat"><span><a href="${esc(c.url)}" target="_blank" rel="noopener">${esc(c.login)}</a></span><span>${fmt(c.contributions)}</span></div>`).join('')}
       </div>`;
 
     const release = r.latest_release ? `
       <div class="card">
         <h4>Latest release</h4>
-        <div class="stat"><span>Tag</span><span><a href="${r.latest_release.url}" target="_blank" rel="noopener">${r.latest_release.tag_name}</a></span></div>
-        <div class="stat"><span>Published</span><span>${r.latest_release.published_at ? new Date(r.latest_release.published_at).toLocaleDateString() : '—'}</span></div>
+        <div class="stat"><span>Tag</span><span><a href="${esc(r.latest_release.url)}" target="_blank" rel="noopener">${esc(r.latest_release.tag_name)}</a></span></div>
+        <div class="stat"><span>Published</span><span>${r.latest_release.published_at ? esc(new Date(r.latest_release.published_at).toLocaleDateString()) : '—'}</span></div>
         <div class="stat"><span>Release downloads (total)</span><span>${fmt(r.lifetime.release_downloads)}</span></div>
       </div>` : '';
 
     document.getElementById('detail-body').innerHTML = `
-      <p>${r.description || ''}</p>
+      <p>${esc(r.description || '')}</p>
       <div class="detail-grid">
         ${contributors}
         ${release}

--- a/dashboard/assets/dashboard.js
+++ b/dashboard/assets/dashboard.js
@@ -9,11 +9,13 @@
       ['forks', 'Forks'],
       ['contributors', 'Contributors'],
       ['external_contributors', 'External contrib.'],
+      ['dependents_repos', 'Used by (repos)'],
       ['issues_closed', 'Issues closed'],
       ['prs_merged', 'PRs merged'],
       ['releases', 'Releases'],
       ['commits', 'Commits'],
       ['packagist_downloads', 'Packagist DL'],
+      ['ghcr_downloads', 'GHCR pulls'],
     ],
     recent_30d: [
       ['commits_30d', 'Commits'],
@@ -22,6 +24,7 @@
       ['prs_merged_30d', 'PRs merged'],
       ['releases_30d', 'Releases'],
       ['packagist_downloads_30d', 'Packagist DL'],
+      ['ghcr_downloads_30d', 'GHCR pulls'],
     ],
   };
 
@@ -90,6 +93,8 @@
           <div class="stat"><span>External contrib.</span><span>${fmt(sum(['lifetime', 'external_contributors']))}</span></div>
           <div class="stat"><span>Releases</span><span>${fmt(sum(['lifetime', 'releases']))}</span></div>
           <div class="stat"><span>Packagist DL</span><span>${fmt(sum(['lifetime', 'packagist_downloads']))}</span></div>
+          <div class="stat"><span>GHCR pulls</span><span>${fmt(sum(['lifetime', 'ghcr_downloads']))}</span></div>
+          <div class="stat"><span>Used by (repos)</span><span>${fmt(sum(['lifetime', 'dependents_repos']))}</span></div>
           <div class="stat"><span>Commits (30d)</span><span>${fmt(sum(['recent_30d', 'commits']))}</span></div>
         </div>`;
     }
@@ -172,6 +177,7 @@
       }
       if (k === 'commits_30d') { va = a.recent_30d?.commits ?? 0; vb = b.recent_30d?.commits ?? 0; }
       else if (k === 'blast_radius') { va = a.blast_radius ?? 0; vb = b.blast_radius ?? 0; }
+      else if (k === 'dependents_repos') { va = a.lifetime?.dependents_repos ?? 0; vb = b.lifetime?.dependents_repos ?? 0; }
       else { va = a.lifetime?.[k] ?? 0; vb = b.lifetime?.[k] ?? 0; }
       return state.sortDir * (va - vb);
     });
@@ -192,6 +198,8 @@
         <td class="num">${fmt(r.lifetime.releases)}</td>
         <td class="num">${fmt(r.recent_30d.commits)}</td>
         <td class="num">${fmt(r.lifetime.packagist_downloads)}</td>
+        <td class="num">${fmt(r.lifetime.ghcr_downloads)}</td>
+        <td class="num">${fmt(r.lifetime.dependents_repos)}</td>
         <td class="num">${fmt(r.blast_radius)}</td>
       </tr>`).join('');
   }
@@ -222,6 +230,22 @@
         <p><a href="${r.packagist.url}" target="_blank" rel="noopener">${r.packagist.name}</a></p>
       </div>` : '';
 
+    const ghcr = r.ghcr ? `
+      <div class="card">
+        <h4>GHCR pulls</h4>
+        <div class="stat"><span>Total (lifetime)</span><span>${fmt(r.ghcr.total)}</span></div>
+        <div class="stat"><span>Last 30 days</span><span>${fmt(r.ghcr.thirty_day)}</span></div>
+        ${r.ghcr.packages.map(p => `<p><a href="${p.url}" target="_blank" rel="noopener">${p.package}</a>: ${fmt(p.total)} total / ${fmt(p.thirty_day)} 30d</p>`).join('')}
+      </div>` : '';
+
+    const dependents = r.dependents ? `
+      <div class="card">
+        <h4>Used by (dependents)</h4>
+        <div class="stat"><span>Repositories</span><span>${fmt(r.dependents.repositories)}</span></div>
+        <div class="stat"><span>Packages</span><span>${fmt(r.dependents.packages)}</span></div>
+        <p><a href="${r.dependents.url}" target="_blank" rel="noopener">View dependents graph →</a></p>
+      </div>` : '';
+
     const contributors = `
       <div class="card">
         <h4>Top contributors</h4>
@@ -242,6 +266,8 @@
         ${contributors}
         ${release}
         ${packagist}
+        ${ghcr}
+        ${dependents}
         ${trafficBlock}
       </div>`;
     panel.hidden = false;

--- a/dashboard/assets/styles.css
+++ b/dashboard/assets/styles.css
@@ -1,0 +1,228 @@
+:root {
+  --nr-teal: #2F99A4;
+  --nr-orange: #FF4D00;
+  --nr-gray: #585961;
+  --bg: #0f1115;
+  --bg-surface: #1a1d23;
+  --bg-surface-2: #22262e;
+  --fg: #e8eaed;
+  --fg-muted: #9aa0a6;
+  --border: #2a2f38;
+  --accent: var(--nr-teal);
+  --accent-2: var(--nr-orange);
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: 'Open Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+h1, h2, h3 {
+  font-family: 'Raleway', 'Open Sans', sans-serif;
+  font-weight: 600;
+  margin: 0 0 .5rem;
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1rem 1.5rem;
+}
+
+.site-header {
+  background: linear-gradient(135deg, #0f1115, #1a1d23);
+  border-bottom: 1px solid var(--border);
+  padding: 1.5rem 0;
+}
+
+.site-header h1 { font-size: 1.75rem; }
+.site-header .subtitle { color: var(--fg-muted); margin: .25rem 0 0; }
+.site-header .meta { color: var(--fg-muted); font-size: .85rem; margin-top: .75rem; }
+
+.site-footer {
+  border-top: 1px solid var(--border);
+  padding: 1rem 0;
+  color: var(--fg-muted);
+  font-size: .85rem;
+  margin-top: 3rem;
+}
+
+.scope-toggle {
+  display: flex;
+  gap: .5rem;
+  margin: 1.5rem 0 1rem;
+}
+
+.toggle {
+  background: var(--bg-surface);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  padding: .5rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font: inherit;
+}
+
+.toggle.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.kpis {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: .75rem;
+  margin-bottom: 2rem;
+}
+
+.kpi {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.kpi .kpi-label {
+  color: var(--fg-muted);
+  font-size: .75rem;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+}
+
+.kpi .kpi-value {
+  font-size: 1.75rem;
+  font-weight: 600;
+  margin-top: .25rem;
+  font-family: 'Raleway', sans-serif;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.card h3 { color: var(--accent); }
+.card .stat { display: flex; justify-content: space-between; padding: .125rem 0; font-size: .9rem; }
+.card .stat span:first-child { color: var(--fg-muted); }
+
+.chart-section { margin: 2rem 0; }
+.chart-note { color: var(--fg-muted); font-size: .85rem; }
+.chart-wrap {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  height: 320px;
+}
+
+.filter-bar {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: .75rem;
+}
+
+.filter-bar input[type="search"] {
+  flex: 1;
+  min-width: 200px;
+  background: var(--bg-surface);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  padding: .5rem .75rem;
+  border-radius: 6px;
+  font: inherit;
+}
+
+.filter-bar label { color: var(--fg-muted); cursor: pointer; }
+
+.table-wrap {
+  overflow-x: auto;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: .875rem;
+}
+
+th, td {
+  padding: .5rem .75rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+th {
+  background: var(--bg-surface-2);
+  cursor: pointer;
+  user-select: none;
+  font-weight: 600;
+  color: var(--fg-muted);
+  position: sticky;
+  top: 0;
+}
+
+th.num, td.num { text-align: right; font-variant-numeric: tabular-nums; }
+
+tbody tr:hover { background: rgba(47, 153, 164, 0.08); }
+tbody tr { cursor: pointer; }
+
+.pill {
+  display: inline-block;
+  padding: .1rem .5rem;
+  border-radius: 999px;
+  background: var(--bg-surface-2);
+  color: var(--fg-muted);
+  font-size: .7rem;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+}
+
+.pill.typo3 { background: rgba(47, 153, 164, 0.18); color: var(--nr-teal); }
+.pill.skill { background: rgba(255, 77, 0, 0.18); color: var(--nr-orange); }
+
+#repo-detail {
+  margin-top: 2rem;
+  padding: 1.25rem;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+#repo-detail h2 { color: var(--accent); }
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.detail-grid .card h4 { margin: 0 0 .5rem; color: var(--accent-2); font-size: .85rem; text-transform: uppercase; letter-spacing: .05em; }
+
+.referrer-list { margin: 0; padding-left: 1rem; }
+.referrer-list li { font-size: .85rem; }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -58,6 +58,8 @@
               <th data-sort="releases" class="num">Releases</th>
               <th data-sort="commits_30d" class="num">Commits 30d</th>
               <th data-sort="packagist_downloads" class="num">Packagist</th>
+              <th data-sort="ghcr_downloads" class="num">GHCR</th>
+              <th data-sort="dependents_repos" class="num">Used by</th>
               <th data-sort="blast_radius" class="num">Blast radius</th>
             </tr>
           </thead>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Netresearch · Open Source Impact Dashboard</title>
+  <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container">
+      <h1>Netresearch Open Source Impact</h1>
+      <p class="subtitle">TYPO3 extensions &amp; AI agent skills on <a href="https://github.com/netresearch">github.com/netresearch</a></p>
+      <p id="meta" class="meta">Loading…</p>
+    </div>
+  </header>
+
+  <main class="container">
+
+    <section class="scope-toggle">
+      <button class="toggle active" data-scope="lifetime" type="button">Lifetime</button>
+      <button class="toggle" data-scope="recent_30d" type="button">Last 30 days</button>
+    </section>
+
+    <section class="kpis" id="kpis" aria-label="Key metrics"></section>
+
+    <section class="category-split">
+      <h2>By category</h2>
+      <div id="category-cards" class="cards"></div>
+    </section>
+
+    <section class="chart-section">
+      <h2>Growth over time</h2>
+      <p class="chart-note">Daily snapshots captured by <a href="https://github.com/netresearch/maint/actions/workflows/impact-dashboard.yml">impact-dashboard workflow</a>. Traffic data requires a PAT (see <a href="https://github.com/netresearch/maint#impact-dashboard">setup</a>).</p>
+      <div class="chart-wrap"><canvas id="chart-stars"></canvas></div>
+      <div class="chart-wrap"><canvas id="chart-activity"></canvas></div>
+    </section>
+
+    <section class="repo-table-section">
+      <h2>Repositories</h2>
+      <div class="filter-bar">
+        <input type="search" id="repo-filter" placeholder="Filter repos…" aria-label="Filter repositories">
+        <label><input type="checkbox" id="filter-t3x" checked> TYPO3 extensions</label>
+        <label><input type="checkbox" id="filter-skill" checked> Skills</label>
+      </div>
+      <div class="table-wrap">
+        <table id="repo-table">
+          <thead>
+            <tr>
+              <th data-sort="name">Repo</th>
+              <th data-sort="language">Lang</th>
+              <th data-sort="stars" class="num">★</th>
+              <th data-sort="forks" class="num">Forks</th>
+              <th data-sort="contributors" class="num">Contrib.</th>
+              <th data-sort="external_contributors" class="num">External</th>
+              <th data-sort="issues_open" class="num">Issues</th>
+              <th data-sort="prs_merged" class="num">PRs merged</th>
+              <th data-sort="releases" class="num">Releases</th>
+              <th data-sort="commits_30d" class="num">Commits 30d</th>
+              <th data-sort="packagist_downloads" class="num">Packagist</th>
+              <th data-sort="blast_radius" class="num">Blast radius</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </section>
+
+    <section id="repo-detail" hidden>
+      <h2 id="detail-title"></h2>
+      <div id="detail-body"></div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <p>
+        Data collected from the <a href="https://docs.github.com/en/rest">GitHub REST API</a> and
+        <a href="https://packagist.org/">Packagist</a>.
+        Source: <a href="https://github.com/netresearch/maint">netresearch/maint</a>.
+      </p>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+  <script src="assets/dashboard.js"></script>
+</body>
+</html>

--- a/scripts/collect_impact.py
+++ b/scripts/collect_impact.py
@@ -19,7 +19,6 @@ import os
 import re
 import sys
 import time
-from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from urllib.parse import quote
@@ -27,11 +26,14 @@ from urllib.parse import quote
 import requests
 
 GITHUB_API = "https://api.github.com"
+GITHUB_WEB = "https://github.com"
 ORG_NAME = os.environ.get("ORG_NAME", "netresearch")
 OUTPUT_DIR = Path(os.environ.get("OUTPUT_DIR", "build"))
 CORE_TOKEN = os.environ["GITHUB_TOKEN"]
 TRAFFIC_TOKEN = os.environ.get("IMPACT_DASHBOARD_PAT") or None
 REPO_PATTERNS = [re.compile(r"^t3x-"), re.compile(r"-skill$")]
+SCRAPE_UA = "netresearch-impact-dashboard/1.0 (+https://github.com/netresearch/maint)"
+SCRAPE_HEADERS = {"User-Agent": SCRAPE_UA, "Accept": "text/html"}
 
 NOW = datetime.now(timezone.utc)
 TODAY = NOW.date().isoformat()
@@ -248,10 +250,133 @@ def fetch_composer_name(full_name: str, default_branch: str) -> str | None:
     return name if isinstance(name, str) and "/" in name else None
 
 
+# ---- HTML scrapers (no public API) ---------------------------------------
+
+
+def scrape_html(url: str) -> str | None:
+    try:
+        r = requests.get(url, headers=SCRAPE_HEADERS, timeout=30, allow_redirects=True)
+        if r.status_code == 404:
+            return None
+        r.raise_for_status()
+        return r.text
+    except requests.RequestException as e:
+        print(f"  scrape failed {url}: {e}", file=sys.stderr)
+        return None
+
+
+def list_org_containers() -> dict[str, list[str]]:
+    """Map repo name -> list of GHCR container package names owned by that repo.
+
+    Requires a token with `read:packages` scope. If unavailable (403), returns
+    an empty map and the collector falls back to probing package URLs per repo.
+    """
+    url = f"{GITHUB_API}/orgs/{ORG_NAME}/packages?package_type=container&per_page=100"
+    try:
+        packages = gh_get_all(url)
+    except requests.HTTPError as e:
+        if e.response is not None and e.response.status_code in (401, 403, 404):
+            print(
+                f"  container listing unavailable ({e.response.status_code}); "
+                "will probe each repo for a package named after it",
+                file=sys.stderr,
+            )
+            return {}
+        raise
+    mapping: dict[str, list[str]] = {}
+    for pkg in packages:
+        repo = (pkg.get("repository") or {}).get("name")
+        name = pkg.get("name")
+        if repo and name:
+            mapping.setdefault(repo, []).append(name)
+    return mapping
+
+
+# Matches: <h3 title="130712">131K</h3> following a "Total downloads" label.
+_GHCR_TOTAL_RE = re.compile(
+    r'Total downloads</span>\s*<h3[^>]*title="(\d+)"',
+    re.DOTALL,
+)
+# Matches the 30-day sparkline block by its aria-label.
+_GHCR_30D_BLOCK_RE = re.compile(
+    r'aria-label="Downloads for the last 30 days".*?</svg>',
+    re.DOTALL,
+)
+_GHCR_MERGE_COUNT_RE = re.compile(r'data-merge-count="(\d+)"')
+
+
+def fetch_ghcr_stats(repo: str, pkg: str) -> dict | None:
+    """Scrape the package overview page for total + last-30-day download counts."""
+    url = f"{GITHUB_WEB}/{ORG_NAME}/{repo}/pkgs/container/{pkg}"
+    html = scrape_html(url)
+    if not html:
+        return None
+    total_m = _GHCR_TOTAL_RE.search(html)
+    block_m = _GHCR_30D_BLOCK_RE.search(html)
+    thirty_day = 0
+    if block_m:
+        thirty_day = sum(int(x) for x in _GHCR_MERGE_COUNT_RE.findall(block_m.group(0)))
+    return {
+        "package": pkg,
+        "url": url,
+        "total": int(total_m.group(1)) if total_m else 0,
+        "thirty_day": thirty_day,
+    }
+
+
+def fetch_ghcr_for_repo(repo: str, pkg_names: list[str]) -> dict | None:
+    """Aggregate GHCR stats across all container packages owned by a repo.
+
+    If pkg_names is empty (no API listing available), probe `{repo}` as the
+    package name (common convention, e.g. netresearch/ofelia publishes `ofelia`).
+    """
+    probe_names = pkg_names or [repo]
+    packages = []
+    for p in probe_names:
+        s = fetch_ghcr_stats(repo, p)
+        if s is not None:
+            packages.append(s)
+    if not packages:
+        return None
+    return {
+        "packages": packages,
+        "total": sum(p["total"] for p in packages),
+        "thirty_day": sum(p["thirty_day"] for p in packages),
+    }
+
+
+# Matches: <a ... dependent_type=REPOSITORY"> ... </svg> 1,234 Repositories
+_DEPENDENTS_REPO_RE = re.compile(
+    r'dependent_type=REPOSITORY"[^>]*>.*?</svg>\s*([\d,]+)\s*Repositories',
+    re.DOTALL,
+)
+_DEPENDENTS_PKG_RE = re.compile(
+    r'dependent_type=PACKAGE"[^>]*>.*?</svg>\s*([\d,]+)\s*Packages',
+    re.DOTALL,
+)
+
+
+def fetch_dependents(full_name: str) -> dict | None:
+    """Scrape /network/dependents for the "Used by" counts (repositories + packages)."""
+    url = f"{GITHUB_WEB}/{full_name}/network/dependents"
+    html = scrape_html(url)
+    if html is None:
+        return None
+
+    def _to_int(m: re.Match | None) -> int:
+        return int(m.group(1).replace(",", "")) if m else 0
+
+    return {
+        "repositories": _to_int(_DEPENDENTS_REPO_RE.search(html)),
+        "packages": _to_int(_DEPENDENTS_PKG_RE.search(html)),
+        "url": url,
+    }
+
+
 # ---- aggregation ----------------------------------------------------------
 
 
-def collect_repo(repo: dict, org_members: set[str]) -> dict:
+def collect_repo(repo: dict, org_members: set[str], container_map: dict[str, list[str]]) -> dict:
     full = repo["full_name"]
     name = repo["name"]
     print(f"[{name}] collecting", file=sys.stderr)
@@ -270,11 +395,15 @@ def collect_repo(repo: dict, org_members: set[str]) -> dict:
         if composer:
             packagist = fetch_packagist(composer)
 
+    ghcr = fetch_ghcr_for_repo(name, container_map.get(name, []))
+    dependents = fetch_dependents(full)
+
     blast_radius = (
         contribs["external_contributors"] * 3
         + issue_pr["issues_open"] + issue_pr["issues_closed"]
         + issue_pr["prs_merged"]
         + repo.get("forks_count", 0) * 2
+        + (dependents or {}).get("repositories", 0) * 2
     )
 
     return {
@@ -305,6 +434,9 @@ def collect_repo(repo: dict, org_members: set[str]) -> dict:
             "contributors": contribs["contributors"],
             "external_contributors": contribs["external_contributors"],
             "packagist_downloads": (packagist or {}).get("total", 0) if packagist else 0,
+            "ghcr_downloads": (ghcr or {}).get("total", 0),
+            "dependents_repos": (dependents or {}).get("repositories", 0),
+            "dependents_packages": (dependents or {}).get("packages", 0),
         },
         "recent_30d": {
             "commits": commits_30d,
@@ -313,11 +445,14 @@ def collect_repo(repo: dict, org_members: set[str]) -> dict:
             "prs_merged": issue_pr["prs_merged_30d"],
             "releases": releases["releases_30d"],
             "packagist_downloads": (packagist or {}).get("monthly", 0) if packagist else 0,
+            "ghcr_downloads": (ghcr or {}).get("thirty_day", 0),
         },
         "traffic_14d": traffic,
         "latest_release": releases["latest"],
         "top_contributors": contribs["top"],
         "packagist": packagist,
+        "ghcr": ghcr,
+        "dependents": dependents,
         "blast_radius": blast_radius,
     }
 
@@ -351,12 +486,16 @@ def aggregate_totals(repos: list[dict]) -> dict:
         "contributors": sum_of(("lifetime", "contributors")),
         "external_contributors": sum_of(("lifetime", "external_contributors")),
         "packagist_downloads": sum_of(("lifetime", "packagist_downloads")),
+        "ghcr_downloads": sum_of(("lifetime", "ghcr_downloads")),
+        "dependents_repos": sum_of(("lifetime", "dependents_repos")),
+        "dependents_packages": sum_of(("lifetime", "dependents_packages")),
         "commits_30d": sum_of(("recent_30d", "commits")),
         "issues_opened_30d": sum_of(("recent_30d", "issues_opened")),
         "prs_opened_30d": sum_of(("recent_30d", "prs_opened")),
         "prs_merged_30d": sum_of(("recent_30d", "prs_merged")),
         "releases_30d": sum_of(("recent_30d", "releases")),
         "packagist_downloads_30d": sum_of(("recent_30d", "packagist_downloads")),
+        "ghcr_downloads_30d": sum_of(("recent_30d", "ghcr_downloads")),
     }
 
 
@@ -419,10 +558,14 @@ def main() -> int:
     members = list_public_members()
     print(f"Known public org members: {len(members)}", file=sys.stderr)
 
+    print("Enumerating org container packages (GHCR)...", file=sys.stderr)
+    containers = list_org_containers()
+    print(f"Container packages discovered: {sum(len(v) for v in containers.values())} across {len(containers)} repos", file=sys.stderr)
+
     collected: list[dict] = []
     for repo in repos:
         try:
-            collected.append(collect_repo(repo, members))
+            collected.append(collect_repo(repo, members, containers))
         except requests.HTTPError as e:
             print(f"  ERROR {repo['name']}: {e}", file=sys.stderr)
 

--- a/scripts/collect_impact.py
+++ b/scripts/collect_impact.py
@@ -31,7 +31,6 @@ ORG_NAME = os.environ.get("ORG_NAME", "netresearch")
 OUTPUT_DIR = Path(os.environ.get("OUTPUT_DIR", "build"))
 CORE_TOKEN = os.environ["GITHUB_TOKEN"]
 TRAFFIC_TOKEN = os.environ.get("IMPACT_DASHBOARD_PAT") or None
-REPO_PATTERNS = [re.compile(r"^t3x-"), re.compile(r"-skill$")]
 SCRAPE_UA = "netresearch-impact-dashboard/1.0 (+https://github.com/netresearch/maint)"
 SCRAPE_HEADERS = {"User-Agent": SCRAPE_UA, "Accept": "text/html"}
 
@@ -51,7 +50,14 @@ def auth_headers(token: str = CORE_TOKEN) -> dict[str, str]:
 def gh_get(url: str, token: str = CORE_TOKEN, allow_status: tuple[int, ...] = ()) -> requests.Response:
     """GET with built-in retry for transient errors and secondary rate limits."""
     for attempt in range(4):
-        r = requests.get(url, headers=auth_headers(token), timeout=30)
+        try:
+            r = requests.get(url, headers=auth_headers(token), timeout=30)
+        except requests.RequestException as e:
+            if attempt < 3:
+                print(f"  network error ({type(e).__name__}), retrying", file=sys.stderr)
+                time.sleep(2 ** attempt)
+                continue
+            raise
         if r.status_code in allow_status:
             return r
         if r.status_code in (403, 429) and "rate limit" in r.text.lower():
@@ -231,7 +237,7 @@ def fetch_packagist(composer_name: str) -> dict | None:
             "url": f"https://packagist.org/packages/{composer_name}",
         }
     except requests.RequestException as e:
-        print(f"  packagist lookup failed for {composer_name}: {e}", file=sys.stderr)
+        print(f"  packagist lookup failed for {composer_name}: {type(e).__name__}", file=sys.stderr)
         return None
 
 
@@ -261,7 +267,7 @@ def scrape_html(url: str) -> str | None:
         r.raise_for_status()
         return r.text
     except requests.RequestException as e:
-        print(f"  scrape failed {url}: {e}", file=sys.stderr)
+        print(f"  scrape failed {url}: {type(e).__name__}", file=sys.stderr)
         return None
 
 
@@ -567,7 +573,8 @@ def main() -> int:
         try:
             collected.append(collect_repo(repo, members, containers))
         except requests.HTTPError as e:
-            print(f"  ERROR {repo['name']}: {e}", file=sys.stderr)
+            status = e.response.status_code if e.response is not None else "?"
+            print(f"  ERROR {repo['name']}: HTTP {status}", file=sys.stderr)
 
     snapshot = {
         "generated_at": NOW.isoformat(timespec="seconds"),

--- a/scripts/collect_impact.py
+++ b/scripts/collect_impact.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Collect GitHub impact metrics for netresearch TYPO3 extensions and skill repos.
+
+Writes JSON snapshots under ./build/data/ for consumption by the static dashboard:
+  data/latest.json              Current snapshot of all repos
+  data/snapshots/YYYY-MM-DD.json Daily archive (point-in-time)
+  data/history.json             Append-only daily rollup for time-series charts
+  data/repos/<name>.json        Per-repo detail
+
+Core metrics work with the workflow's built-in GITHUB_TOKEN.
+Traffic metrics (clones/views/referrers) require a PAT with `repo` scope on the
+target repos; set IMPACT_DASHBOARD_PAT. Without it, traffic is omitted.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from urllib.parse import quote
+
+import requests
+
+GITHUB_API = "https://api.github.com"
+ORG_NAME = os.environ.get("ORG_NAME", "netresearch")
+OUTPUT_DIR = Path(os.environ.get("OUTPUT_DIR", "build"))
+CORE_TOKEN = os.environ["GITHUB_TOKEN"]
+TRAFFIC_TOKEN = os.environ.get("IMPACT_DASHBOARD_PAT") or None
+REPO_PATTERNS = [re.compile(r"^t3x-"), re.compile(r"-skill$")]
+
+NOW = datetime.now(timezone.utc)
+TODAY = NOW.date().isoformat()
+WINDOW_30D = (NOW - timedelta(days=30)).isoformat()
+
+
+def auth_headers(token: str = CORE_TOKEN) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def gh_get(url: str, token: str = CORE_TOKEN, allow_status: tuple[int, ...] = ()) -> requests.Response:
+    """GET with built-in retry for transient errors and secondary rate limits."""
+    for attempt in range(4):
+        r = requests.get(url, headers=auth_headers(token), timeout=30)
+        if r.status_code in allow_status:
+            return r
+        if r.status_code in (403, 429) and "rate limit" in r.text.lower():
+            reset = int(r.headers.get("x-ratelimit-reset", "0"))
+            wait = max(5, min(60, reset - int(time.time()))) if reset else 15
+            print(f"  rate-limited, sleeping {wait}s", file=sys.stderr)
+            time.sleep(wait)
+            continue
+        if r.status_code >= 500 and attempt < 3:
+            time.sleep(2 ** attempt)
+            continue
+        r.raise_for_status()
+        return r
+    r.raise_for_status()
+    return r
+
+
+def gh_get_all(url: str, token: str = CORE_TOKEN) -> list[dict]:
+    """Paginate through a list endpoint and return all items."""
+    results: list[dict] = []
+    while url:
+        r = gh_get(url, token=token)
+        data = r.json()
+        if not isinstance(data, list):
+            return data  # type: ignore[return-value]
+        results.extend(data)
+        url = r.links.get("next", {}).get("url")  # type: ignore[assignment]
+    return results
+
+
+def search_count(q: str) -> int:
+    """Return total_count from the issues/PRs search API."""
+    url = f"{GITHUB_API}/search/issues?q={quote(q)}&per_page=1"
+    r = gh_get(url)
+    return int(r.json().get("total_count", 0))
+
+
+def count_commits_since(full_name: str, since_iso: str | None = None) -> int:
+    """Use the Link header's last-page trick to count commits cheaply."""
+    q = f"per_page=1"
+    if since_iso:
+        q += f"&since={since_iso}"
+    url = f"{GITHUB_API}/repos/{full_name}/commits?{q}"
+    r = gh_get(url, allow_status=(409,))
+    if r.status_code == 409:  # empty repo
+        return 0
+    last = r.links.get("last", {}).get("url", "")
+    m = re.search(r"[?&]page=(\d+)", last)
+    if m:
+        return int(m.group(1))
+    return len(r.json())
+
+
+# ---- repo discovery -------------------------------------------------------
+
+
+def classify(name: str) -> str | None:
+    if name.startswith("t3x-"):
+        return "typo3-extension"
+    if name.endswith("-skill"):
+        return "skill"
+    return None
+
+
+def list_target_repos() -> list[dict]:
+    repos = gh_get_all(f"{GITHUB_API}/orgs/{ORG_NAME}/repos?type=public&per_page=100")
+    selected = []
+    for r in repos:
+        if r.get("archived") or r.get("private"):
+            continue
+        category = classify(r["name"])
+        if category is None:
+            continue
+        r["_category"] = category
+        selected.append(r)
+    selected.sort(key=lambda r: r["name"])
+    return selected
+
+
+def list_public_members() -> set[str]:
+    members = gh_get_all(f"{GITHUB_API}/orgs/{ORG_NAME}/public_members?per_page=100")
+    return {m["login"].lower() for m in members}
+
+
+# ---- per-repo metric fetchers ---------------------------------------------
+
+
+def fetch_issue_pr_counts(full_name: str) -> dict:
+    base = f"repo:{full_name}"
+    recent = f" created:>={WINDOW_30D[:10]}"
+    return {
+        "issues_open": search_count(f"{base} is:issue is:open"),
+        "issues_closed": search_count(f"{base} is:issue is:closed"),
+        "prs_open": search_count(f"{base} is:pr is:open"),
+        "prs_merged": search_count(f"{base} is:pr is:merged"),
+        "prs_closed_unmerged": search_count(f"{base} is:pr is:closed is:unmerged"),
+        "issues_opened_30d": search_count(f"{base} is:issue{recent}"),
+        "prs_opened_30d": search_count(f"{base} is:pr{recent}"),
+        "prs_merged_30d": search_count(f"{base} is:pr is:merged merged:>={WINDOW_30D[:10]}"),
+    }
+
+
+def fetch_releases(full_name: str) -> dict:
+    releases = gh_get_all(f"{GITHUB_API}/repos/{full_name}/releases?per_page=100")
+    total_downloads = sum(
+        a.get("download_count", 0) for rel in releases for a in rel.get("assets", [])
+    )
+    recent = [r for r in releases if r.get("published_at", "") >= WINDOW_30D]
+    latest = releases[0] if releases else None
+    return {
+        "releases": len(releases),
+        "releases_30d": len(recent),
+        "release_downloads": total_downloads,
+        "latest": {
+            "name": latest.get("name") or latest.get("tag_name"),
+            "tag_name": latest.get("tag_name"),
+            "published_at": latest.get("published_at"),
+            "url": latest.get("html_url"),
+        } if latest else None,
+    }
+
+
+def fetch_contributors(full_name: str, org_members: set[str]) -> dict:
+    contribs = gh_get_all(f"{GITHUB_API}/repos/{full_name}/contributors?per_page=100&anon=0")
+    total = len(contribs)
+    external = [c for c in contribs if c.get("login", "").lower() not in org_members and c.get("type") != "Bot"]
+    top = sorted(contribs, key=lambda c: c.get("contributions", 0), reverse=True)[:10]
+    return {
+        "contributors": total,
+        "external_contributors": len(external),
+        "top": [
+            {"login": c.get("login"), "contributions": c.get("contributions", 0), "url": c.get("html_url")}
+            for c in top
+            if c.get("login")
+        ],
+    }
+
+
+def fetch_traffic(full_name: str) -> dict | None:
+    if not TRAFFIC_TOKEN:
+        return None
+    try:
+        clones = gh_get(f"{GITHUB_API}/repos/{full_name}/traffic/clones", token=TRAFFIC_TOKEN).json()
+        views = gh_get(f"{GITHUB_API}/repos/{full_name}/traffic/views", token=TRAFFIC_TOKEN).json()
+        referrers = gh_get(f"{GITHUB_API}/repos/{full_name}/traffic/popular/referrers", token=TRAFFIC_TOKEN).json()
+        paths = gh_get(f"{GITHUB_API}/repos/{full_name}/traffic/popular/paths", token=TRAFFIC_TOKEN).json()
+    except requests.HTTPError as e:
+        if e.response is not None and e.response.status_code in (403, 404):
+            print(f"  traffic unavailable for {full_name}: {e.response.status_code}", file=sys.stderr)
+            return None
+        raise
+    return {
+        "clones_total": clones.get("count", 0),
+        "clones_unique": clones.get("uniques", 0),
+        "views_total": views.get("count", 0),
+        "views_unique": views.get("uniques", 0),
+        "top_referrers": referrers[:10],
+        "top_paths": paths[:10],
+    }
+
+
+def fetch_packagist(composer_name: str) -> dict | None:
+    """Return Packagist download stats if the package is published."""
+    url = f"https://packagist.org/packages/{composer_name}.json"
+    try:
+        r = requests.get(url, timeout=20)
+        if r.status_code == 404:
+            return None
+        r.raise_for_status()
+        pkg = r.json().get("package", {})
+        dl = pkg.get("downloads", {})
+        return {
+            "name": composer_name,
+            "total": dl.get("total", 0),
+            "monthly": dl.get("monthly", 0),
+            "daily": dl.get("daily", 0),
+            "url": f"https://packagist.org/packages/{composer_name}",
+        }
+    except requests.RequestException as e:
+        print(f"  packagist lookup failed for {composer_name}: {e}", file=sys.stderr)
+        return None
+
+
+def fetch_composer_name(full_name: str, default_branch: str) -> str | None:
+    url = f"{GITHUB_API}/repos/{full_name}/contents/composer.json?ref={default_branch}"
+    r = gh_get(url, allow_status=(404,))
+    if r.status_code == 404:
+        return None
+    import base64
+    content = r.json().get("content", "")
+    try:
+        data = json.loads(base64.b64decode(content))
+    except (ValueError, json.JSONDecodeError):
+        return None
+    name = data.get("name")
+    return name if isinstance(name, str) and "/" in name else None
+
+
+# ---- aggregation ----------------------------------------------------------
+
+
+def collect_repo(repo: dict, org_members: set[str]) -> dict:
+    full = repo["full_name"]
+    name = repo["name"]
+    print(f"[{name}] collecting", file=sys.stderr)
+
+    issue_pr = fetch_issue_pr_counts(full)
+    releases = fetch_releases(full)
+    contribs = fetch_contributors(full, org_members)
+    traffic = fetch_traffic(full)
+    commits_total = count_commits_since(full)
+    commits_30d = count_commits_since(full, since_iso=WINDOW_30D)
+
+    composer = None
+    packagist = None
+    if repo.get("language") == "PHP":
+        composer = fetch_composer_name(full, repo.get("default_branch", "main"))
+        if composer:
+            packagist = fetch_packagist(composer)
+
+    blast_radius = (
+        contribs["external_contributors"] * 3
+        + issue_pr["issues_open"] + issue_pr["issues_closed"]
+        + issue_pr["prs_merged"]
+        + repo.get("forks_count", 0) * 2
+    )
+
+    return {
+        "name": name,
+        "full_name": full,
+        "url": repo["html_url"],
+        "description": repo.get("description") or "",
+        "language": repo.get("language"),
+        "category": repo["_category"],
+        "license": (repo.get("license") or {}).get("spdx_id"),
+        "topics": repo.get("topics", []),
+        "homepage": repo.get("homepage") or "",
+        "default_branch": repo.get("default_branch"),
+        "created_at": repo.get("created_at"),
+        "pushed_at": repo.get("pushed_at"),
+        "updated_at": repo.get("updated_at"),
+        "composer_name": composer,
+        "lifetime": {
+            "stars": repo.get("stargazers_count", 0),
+            "forks": repo.get("forks_count", 0),
+            "watchers": repo.get("subscribers_count", 0),
+            "network": repo.get("network_count", 0),
+            "open_issues_plus_prs": repo.get("open_issues_count", 0),
+            "commits": commits_total,
+            **{k: v for k, v in issue_pr.items() if not k.endswith("_30d")},
+            "releases": releases["releases"],
+            "release_downloads": releases["release_downloads"],
+            "contributors": contribs["contributors"],
+            "external_contributors": contribs["external_contributors"],
+            "packagist_downloads": (packagist or {}).get("total", 0) if packagist else 0,
+        },
+        "recent_30d": {
+            "commits": commits_30d,
+            "issues_opened": issue_pr["issues_opened_30d"],
+            "prs_opened": issue_pr["prs_opened_30d"],
+            "prs_merged": issue_pr["prs_merged_30d"],
+            "releases": releases["releases_30d"],
+            "packagist_downloads": (packagist or {}).get("monthly", 0) if packagist else 0,
+        },
+        "traffic_14d": traffic,
+        "latest_release": releases["latest"],
+        "top_contributors": contribs["top"],
+        "packagist": packagist,
+        "blast_radius": blast_radius,
+    }
+
+
+def aggregate_totals(repos: list[dict]) -> dict:
+    def sum_of(path: tuple[str, ...]) -> int:
+        total = 0
+        for r in repos:
+            cur: object = r
+            for key in path:
+                if not isinstance(cur, dict):
+                    cur = None
+                    break
+                cur = cur.get(key)  # type: ignore[union-attr]
+            if isinstance(cur, (int, float)):
+                total += int(cur)
+        return total
+
+    return {
+        "repos": len(repos),
+        "stars": sum_of(("lifetime", "stars")),
+        "forks": sum_of(("lifetime", "forks")),
+        "watchers": sum_of(("lifetime", "watchers")),
+        "commits": sum_of(("lifetime", "commits")),
+        "issues_open": sum_of(("lifetime", "issues_open")),
+        "issues_closed": sum_of(("lifetime", "issues_closed")),
+        "prs_open": sum_of(("lifetime", "prs_open")),
+        "prs_merged": sum_of(("lifetime", "prs_merged")),
+        "releases": sum_of(("lifetime", "releases")),
+        "release_downloads": sum_of(("lifetime", "release_downloads")),
+        "contributors": sum_of(("lifetime", "contributors")),
+        "external_contributors": sum_of(("lifetime", "external_contributors")),
+        "packagist_downloads": sum_of(("lifetime", "packagist_downloads")),
+        "commits_30d": sum_of(("recent_30d", "commits")),
+        "issues_opened_30d": sum_of(("recent_30d", "issues_opened")),
+        "prs_opened_30d": sum_of(("recent_30d", "prs_opened")),
+        "prs_merged_30d": sum_of(("recent_30d", "prs_merged")),
+        "releases_30d": sum_of(("recent_30d", "releases")),
+        "packagist_downloads_30d": sum_of(("recent_30d", "packagist_downloads")),
+    }
+
+
+def load_history(base: Path) -> dict:
+    path = base / "data" / "history.json"
+    if path.exists():
+        try:
+            return json.loads(path.read_text())
+        except json.JSONDecodeError:
+            pass
+    return {"daily": []}
+
+
+def append_history(history: dict, totals: dict) -> dict:
+    daily = [d for d in history.get("daily", []) if d.get("date") != TODAY]
+    daily.append({"date": TODAY, "totals": totals})
+    daily.sort(key=lambda d: d["date"])
+    # Keep roughly 3 years of daily data — plenty for a long-horizon chart.
+    if len(daily) > 1100:
+        daily = daily[-1100:]
+    history["daily"] = daily
+    return history
+
+
+def write_outputs(base: Path, snapshot: dict, history: dict) -> None:
+    (base / "data" / "snapshots").mkdir(parents=True, exist_ok=True)
+    (base / "data" / "repos").mkdir(parents=True, exist_ok=True)
+
+    (base / "data" / "latest.json").write_text(json.dumps(snapshot, indent=2))
+    (base / "data" / "snapshots" / f"{TODAY}.json").write_text(json.dumps(snapshot, indent=2))
+    (base / "data" / "history.json").write_text(json.dumps(history, indent=2))
+
+    for repo in snapshot["repos"]:
+        (base / "data" / "repos" / f"{repo['name']}.json").write_text(json.dumps(repo, indent=2))
+
+
+def copy_dashboard_assets(base: Path) -> None:
+    src = Path(__file__).resolve().parent.parent / "dashboard"
+    if not src.exists():
+        return
+    import shutil
+    for entry in src.iterdir():
+        dst = base / entry.name
+        if entry.is_dir():
+            if dst.exists():
+                shutil.rmtree(dst)
+            shutil.copytree(entry, dst)
+        else:
+            shutil.copy2(entry, dst)
+
+
+def main() -> int:
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    print(f"Scanning {ORG_NAME} for matching repos...", file=sys.stderr)
+    repos = list_target_repos()
+    print(f"Found {len(repos)} repos (t3x-* + *-skill, non-archived).", file=sys.stderr)
+
+    print("Loading org public members...", file=sys.stderr)
+    members = list_public_members()
+    print(f"Known public org members: {len(members)}", file=sys.stderr)
+
+    collected: list[dict] = []
+    for repo in repos:
+        try:
+            collected.append(collect_repo(repo, members))
+        except requests.HTTPError as e:
+            print(f"  ERROR {repo['name']}: {e}", file=sys.stderr)
+
+    snapshot = {
+        "generated_at": NOW.isoformat(timespec="seconds"),
+        "org": ORG_NAME,
+        "traffic_available": TRAFFIC_TOKEN is not None,
+        "totals": aggregate_totals(collected),
+        "repos": collected,
+    }
+
+    history = load_history(OUTPUT_DIR)
+    history = append_history(history, snapshot["totals"])
+
+    write_outputs(OUTPUT_DIR, snapshot, history)
+    copy_dashboard_assets(OUTPUT_DIR)
+
+    print(f"Wrote outputs to {OUTPUT_DIR}/", file=sys.stderr)
+    print(json.dumps(snapshot["totals"], indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Daily GitHub Actions cron (03:00 UTC) collects community-impact metrics across all non-archived `t3x-*` and `*-skill` repos.
- Static Chart.js dashboard (plain HTML, no build step) published to the `gh-pages` branch with `keep_files: true` so snapshots accumulate over time.
- Metrics: stars, forks, issues, PRs, releases, contributors (total + external), commits, Packagist downloads, optional 14-day GitHub traffic.

## Scope (by design)

- ✅ All non-archived repos matching \`t3x-*\` (TYPO3 extensions) or \`*-skill\` (Agent Skills) — ~53 repos today
- ✅ Lifetime and last-30-day metrics
- ✅ Blast-radius score = \`external_contributors*3 + total_issues + prs_merged + forks*2\` (comparative indicator)
- ❌ Dependents / GHCR pulls / TER downloads (no stable API; documented in README)

## Required setup after merge

1. Add secret \`IMPACT_DASHBOARD_PAT\` (fine-grained PAT with \`Administration: Read\` on the target repos) — optional; needed only for traffic data.
2. Run the workflow manually once to create the \`gh-pages\` branch.
3. Enable Pages: Settings → Pages → Source = \`gh-pages\` / root.

See the README \"Impact Dashboard\" section for full docs.

## Smoke-test results (live API, local)

- \`context7-skill\`: traffic works (863 views from Google in 14 days).
- \`t3x-rte_ckeditor_image\`: **1,004,994 lifetime Packagist downloads**, 17,668 last month, 44 external contributors, 442 PRs merged.

## Test plan

- [x] Python syntax check (\`py_compile\`)
- [x] Collector smoke-tested against one \`*-skill\` repo (with PAT) and one \`t3x-*\` repo (without PAT) — both produced valid JSON with expected fields
- [ ] First scheduled/manual run produces a valid \`gh-pages\` branch
- [ ] Dashboard renders at \`https://netresearch.github.io/maint/\` once Pages is enabled