### PR TITLE
Handle any 4xx from GHCR package listing as fallback-eligible

### DIFF
--- a/scripts/collect_impact.py
+++ b/scripts/collect_impact.py
@@ -281,9 +281,12 @@ def list_org_containers() -> dict[str, list[str]]:
     try:
         packages = gh_get_all(url)
     except requests.HTTPError as e:
-        if e.response is not None and e.response.status_code in (401, 403, 404):
+        # Any 4xx on this endpoint means the token can't list org packages;
+        # we always have a probe fallback so this is never a hard error.
+        status = e.response.status_code if e.response is not None else "?"
+        if isinstance(status, int) and 400 <= status < 500:
             print(
-                f"  container listing unavailable ({e.response.status_code}); "
+                f"  container listing unavailable (HTTP {status}); "
                 "will probe each repo for a package named after it",
                 file=sys.stderr,
             )


### PR DESCRIPTION
## Summary

First live dashboard run failed because GitHub returned HTTP 400 (not 403) from `/orgs/netresearch/packages?package_type=container` when using the workflow's default `GITHUB_TOKEN` (no `read:packages` scope). The existing handler only caught 401/403/404 and re-raised 400, crashing the whole collector.

Expand the graceful-degradation range to any 4xx status since the probe fallback (`{repo}` as package name) always works.

Also re-set the \`IMPACT_DASHBOARD_PAT\` secret — the first attempt used the \`VAR=x cmd --body \"\$VAR\"\` bash idiom which expands \`\$VAR\` in the outer shell before the env assignment takes effect, storing the secret as an empty string.

## Test plan

- [x] Python syntax check
- [ ] Workflow completes end-to-end and produces a \`gh-pages\` branch with \`data/latest.json\`