### PR TITLE
Expand scope to Go projects; fix watchers/Issues/SRI

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ Automatically adds new issues and pull requests to the Netresearch TYPO3 project
 
 **File:** `.github/workflows/impact-dashboard.yml`
 
-Collects community-impact metrics for all non-archived `t3x-*` (TYPO3 extensions)
-and `*-skill` (Agent Skills) repositories in the org, renders a static dashboard,
-and publishes it to the `gh-pages` branch.
+Collects community-impact metrics for all non-archived `t3x-*` (TYPO3 extensions),
+`*-skill` (Agent Skills), and Go-language repositories in the org, renders a
+static dashboard, and publishes it to the `gh-pages` branch.
 
 **Schedule:** Daily at 03:00 UTC
 

--- a/dashboard/assets/dashboard.js
+++ b/dashboard/assets/dashboard.js
@@ -10,7 +10,7 @@
       ['contributors', 'Contributors'],
       ['external_contributors', 'External contrib.'],
       ['dependents_repos', 'Used by (repos)'],
-      ['issues_closed', 'Issues closed'],
+      ['issues', 'Issues (all)'],
       ['prs_merged', 'PRs merged'],
       ['releases', 'Releases'],
       ['commits', 'Commits'],
@@ -36,6 +36,14 @@
   function esc(s) {
     return String(s ?? '').replace(/[&<>"']/g, c => ESC_MAP[c]);
   }
+
+  const CATEGORY_META = {
+    'typo3-extension': { cls: 'typo3', label: 'TYPO3' },
+    'skill': { cls: 'skill', label: 'Skill' },
+    'go-project': { cls: 'go', label: 'Go' },
+  };
+  function categoryPillClass(cat) { return (CATEGORY_META[cat] || { cls: '' }).cls; }
+  function categoryPillLabel(cat) { return (CATEGORY_META[cat] || { label: cat || '?' }).label; }
 
   async function loadJSON(path) {
     const res = await fetch(path, { cache: 'no-cache' });
@@ -84,14 +92,17 @@
   }
 
   function renderCategoryCards() {
-    const t3x = state.snapshot.repos.filter(r => r.category === 'typo3-extension');
-    const skills = state.snapshot.repos.filter(r => r.category === 'skill');
+    const groups = [
+      { key: 'typo3-extension', title: 'TYPO3 extensions', cls: 'typo3' },
+      { key: 'skill', title: 'Skills', cls: 'skill' },
+      { key: 'go-project', title: 'Go projects', cls: 'go' },
+    ];
 
     function card(title, cls, repos) {
       const sum = (path) => repos.reduce((acc, r) => acc + (r[path[0]]?.[path[1]] ?? 0), 0);
       return `
         <div class="card">
-          <h3><span class="pill ${cls}">${title}</span> · ${repos.length} repos</h3>
+          <h3><span class="pill ${cls}">${esc(title)}</span> · ${repos.length} repos</h3>
           <div class="stat"><span>Stars</span><span>${fmt(sum(['lifetime', 'stars']))}</span></div>
           <div class="stat"><span>Forks</span><span>${fmt(sum(['lifetime', 'forks']))}</span></div>
           <div class="stat"><span>Contributors</span><span>${fmt(sum(['lifetime', 'contributors']))}</span></div>
@@ -104,8 +115,9 @@
         </div>`;
     }
 
-    document.getElementById('category-cards').innerHTML =
-      card('TYPO3 extensions', 'typo3', t3x) + card('Skills', 'skill', skills);
+    document.getElementById('category-cards').innerHTML = groups
+      .map(g => card(g.title, g.cls, state.snapshot.repos.filter(r => r.category === g.key)))
+      .join('');
   }
 
   function renderCharts() {
@@ -165,10 +177,12 @@
     const filter = document.getElementById('repo-filter').value.toLowerCase();
     const showT3x = document.getElementById('filter-t3x').checked;
     const showSkill = document.getElementById('filter-skill').checked;
+    const showGo = document.getElementById('filter-go').checked;
 
     let rows = state.snapshot.repos.filter(r => {
       if (r.category === 'typo3-extension' && !showT3x) return false;
       if (r.category === 'skill' && !showSkill) return false;
+      if (r.category === 'go-project' && !showGo) return false;
       if (filter && !r.name.toLowerCase().includes(filter) && !(r.description || '').toLowerCase().includes(filter)) return false;
       return true;
     });
@@ -180,9 +194,11 @@
         va = (a[k] || '').toString(); vb = (b[k] || '').toString();
         return state.sortDir * va.localeCompare(vb);
       }
+      const issuesTotal = (r) => (r.lifetime?.issues_open ?? 0) + (r.lifetime?.issues_closed ?? 0);
       if (k === 'commits_30d') { va = a.recent_30d?.commits ?? 0; vb = b.recent_30d?.commits ?? 0; }
       else if (k === 'blast_radius') { va = a.blast_radius ?? 0; vb = b.blast_radius ?? 0; }
       else if (k === 'dependents_repos') { va = a.lifetime?.dependents_repos ?? 0; vb = b.lifetime?.dependents_repos ?? 0; }
+      else if (k === 'issues_total') { va = issuesTotal(a); vb = issuesTotal(b); }
       else { va = a.lifetime?.[k] ?? 0; vb = b.lifetime?.[k] ?? 0; }
       return state.sortDir * (va - vb);
     });
@@ -191,14 +207,14 @@
       <tr data-name="${esc(r.name)}">
         <td>
           <a href="${esc(r.url)}" target="_blank" rel="noopener">${esc(r.name)}</a>
-          <span class="pill ${r.category === 'typo3-extension' ? 'typo3' : 'skill'}">${r.category === 'typo3-extension' ? 'TYPO3' : 'Skill'}</span>
+          <span class="pill ${categoryPillClass(r.category)}">${categoryPillLabel(r.category)}</span>
         </td>
         <td>${esc(r.language || '—')}</td>
         <td class="num">${fmt(r.lifetime.stars)}</td>
         <td class="num">${fmt(r.lifetime.forks)}</td>
         <td class="num">${fmt(r.lifetime.contributors)}</td>
         <td class="num">${fmt(r.lifetime.external_contributors)}</td>
-        <td class="num">${fmt(r.lifetime.issues_open)}</td>
+        <td class="num" title="open: ${fmt(r.lifetime.issues_open)} · closed: ${fmt(r.lifetime.issues_closed)}">${fmt((r.lifetime.issues_open ?? 0) + (r.lifetime.issues_closed ?? 0))}</td>
         <td class="num">${fmt(r.lifetime.prs_merged)}</td>
         <td class="num">${fmt(r.lifetime.releases)}</td>
         <td class="num">${fmt(r.recent_30d.commits)}</td>
@@ -301,6 +317,7 @@
     document.getElementById('repo-filter').addEventListener('input', renderTable);
     document.getElementById('filter-t3x').addEventListener('change', renderTable);
     document.getElementById('filter-skill').addEventListener('change', renderTable);
+    document.getElementById('filter-go').addEventListener('change', renderTable);
 
     document.querySelector('#repo-table tbody').addEventListener('click', (e) => {
       const tr = e.target.closest('tr[data-name]');

--- a/dashboard/assets/styles.css
+++ b/dashboard/assets/styles.css
@@ -204,6 +204,7 @@ tbody tr { cursor: pointer; }
 
 .pill.typo3 { background: rgba(47, 153, 164, 0.18); color: var(--nr-teal); }
 .pill.skill { background: rgba(255, 77, 0, 0.18); color: var(--nr-orange); }
+.pill.go { background: rgba(0, 173, 216, 0.18); color: #00ADD8; }
 
 #repo-detail {
   margin-top: 2rem;

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -84,7 +84,10 @@
     </div>
   </footer>
 
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"
+          integrity="sha384-9nhczxUqK87bcKHh20fSQcTGD4qq5GhayNYSYWqwBkINBhOfQLg/P5HG5lF1urn4"
+          crossorigin="anonymous"
+          referrerpolicy="no-referrer"></script>
   <script src="assets/dashboard.js"></script>
 </body>
 </html>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -10,7 +10,7 @@
   <header class="site-header">
     <div class="container">
       <h1>Netresearch Open Source Impact</h1>
-      <p class="subtitle">TYPO3 extensions &amp; AI agent skills on <a href="https://github.com/netresearch">github.com/netresearch</a></p>
+      <p class="subtitle">TYPO3 extensions, AI agent skills &amp; Go projects on <a href="https://github.com/netresearch">github.com/netresearch</a></p>
       <p id="meta" class="meta">Loading…</p>
     </div>
   </header>
@@ -42,6 +42,7 @@
         <input type="search" id="repo-filter" placeholder="Filter repos…" aria-label="Filter repositories">
         <label><input type="checkbox" id="filter-t3x" checked> TYPO3 extensions</label>
         <label><input type="checkbox" id="filter-skill" checked> Skills</label>
+        <label><input type="checkbox" id="filter-go" checked> Go projects</label>
       </div>
       <div class="table-wrap">
         <table id="repo-table">
@@ -53,7 +54,7 @@
               <th data-sort="forks" class="num">Forks</th>
               <th data-sort="contributors" class="num">Contrib.</th>
               <th data-sort="external_contributors" class="num">External</th>
-              <th data-sort="issues_open" class="num">Issues</th>
+              <th data-sort="issues_total" class="num" title="Open + closed">Issues</th>
               <th data-sort="prs_merged" class="num">PRs merged</th>
               <th data-sort="releases" class="num">Releases</th>
               <th data-sort="commits_30d" class="num">Commits 30d</th>

--- a/scripts/collect_impact.py
+++ b/scripts/collect_impact.py
@@ -114,11 +114,14 @@ def count_commits_since(full_name: str, since_iso: str | None = None) -> int:
 # ---- repo discovery -------------------------------------------------------
 
 
-def classify(name: str) -> str | None:
+def classify(repo: dict) -> str | None:
+    name = repo.get("name", "")
     if name.startswith("t3x-"):
         return "typo3-extension"
     if name.endswith("-skill"):
         return "skill"
+    if repo.get("language") == "Go":
+        return "go-project"
     return None
 
 
@@ -128,7 +131,7 @@ def list_target_repos() -> list[dict]:
     for r in repos:
         if r.get("archived") or r.get("private"):
             continue
-        category = classify(r["name"])
+        category = classify(r)
         if category is None:
             continue
         r["_category"] = category
@@ -395,9 +398,9 @@ def collect_repo(repo: dict, org_members: set[str], container_map: dict[str, lis
     try:
         full_repo = gh_get(f"{GITHUB_API}/repos/{full}").json()
         repo = {**repo, **full_repo, "_category": repo["_category"]}
-    except requests.HTTPError as e:
-        status = e.response.status_code if e.response is not None else "?"
-        print(f"  full repo fetch failed (HTTP {status}), using list data", file=sys.stderr)
+    except requests.RequestException as e:
+        status = e.response.status_code if isinstance(e, requests.HTTPError) and e.response is not None else type(e).__name__
+        print(f"  full repo fetch failed ({status}), using list data", file=sys.stderr)
 
     issue_pr = fetch_issue_pr_counts(full)
     releases = fetch_releases(full)
@@ -447,6 +450,7 @@ def collect_repo(repo: dict, org_members: set[str], container_map: dict[str, lis
             "open_issues_plus_prs": repo.get("open_issues_count", 0),
             "commits": commits_total,
             **{k: v for k, v in issue_pr.items() if not k.endswith("_30d")},
+            "issues_total": issue_pr["issues_open"] + issue_pr["issues_closed"],
             "releases": releases["releases"],
             "release_downloads": releases["release_downloads"],
             "contributors": contribs["contributors"],
@@ -497,6 +501,7 @@ def aggregate_totals(repos: list[dict]) -> dict:
         "commits": sum_of(("lifetime", "commits")),
         "issues_open": sum_of(("lifetime", "issues_open")),
         "issues_closed": sum_of(("lifetime", "issues_closed")),
+        "issues": sum_of(("lifetime", "issues_total")),
         "prs_open": sum_of(("lifetime", "prs_open")),
         "prs_merged": sum_of(("lifetime", "prs_merged")),
         "releases": sum_of(("lifetime", "releases")),

--- a/scripts/collect_impact.py
+++ b/scripts/collect_impact.py
@@ -390,6 +390,15 @@ def collect_repo(repo: dict, org_members: set[str], container_map: dict[str, lis
     name = repo["name"]
     print(f"[{name}] collecting", file=sys.stderr)
 
+    # The /orgs/{org}/repos list endpoint returns a simplified repo object
+    # without subscribers_count or network_count. Fetch the full object.
+    try:
+        full_repo = gh_get(f"{GITHUB_API}/repos/{full}").json()
+        repo = {**repo, **full_repo, "_category": repo["_category"]}
+    except requests.HTTPError as e:
+        status = e.response.status_code if e.response is not None else "?"
+        print(f"  full repo fetch failed (HTTP {status}), using list data", file=sys.stderr)
+
     issue_pr = fetch_issue_pr_counts(full)
     releases = fetch_releases(full)
     contribs = fetch_contributors(full, org_members)


### PR DESCRIPTION
## Summary

Three code changes bundled:

### 1. Scope expansion — Go projects (new)

`classify()` now recognizes `repo.language == "Go"` as a third category (`go-project`) alongside `t3x-*` (TYPO3 extensions) and `*-skill` (agent skills). Picks up ~7 repos today: `go-cron`, `ldap-manager`, `ldap-selfservice-password-changer`, `ofelia`, `raybeam`, `simple-ldap-go`, `terraform-provider-ad`.

Consequence: `ofelia` alone has **130K+ lifetime GHCR pulls** + 47K in the last 30 days. The dashboard previously showed `ghcr_downloads: 0` because none of the 54 TYPO3 extensions or skills publish containers.

Dashboard adds a third filter checkbox, a third category card (teal-cyan "go" pill matching the Go brand), and the subtitle reads "TYPO3 extensions, AI agent skills & Go projects."

### 2. Bug fix — watchers always zero

The `/orgs/{org}/repos` list endpoint returns a simplified repo object that omits `subscribers_count` and `network_count`. On the first live run all 54 repos reported `watchers: 0`. Fetching the full object via `GET /repos/{full_name}` in `collect_repo` populates both fields correctly. Cost: ~+54 API calls per run (~1% of the 5000/hr core budget).

Also catches `requests.RequestException` (not just `HTTPError`) for this enrichment so a network-level failure falls back to list data rather than crashing — addresses @gemini-code-assist feedback on the original patch.

### 3. UX fix — Issues column counts all issues

The table's "Issues" column previously displayed open-only. Now shows **open + closed** (total lifetime issue volume). Tooltip on the cell splits it back into open/closed for precision. Added `issues_total` to per-repo lifetime and `issues` to aggregate totals; the lifetime KPI panel now has "Issues (all)" instead of "Issues closed".

### 4. Supply-chain — Chart.js SRI

Pin `chart.js@4.4.1` from jsdelivr with the computed SHA-384 hash + `crossorigin="anonymous"` + `referrerpolicy="no-referrer"`. This is the only third-party script the dashboard loads.

## Test plan

- [x] Python + JS syntax check
- [ ] Workflow run completes end-to-end
- [ ] Go projects appear on https://netresearch.github.io/maint/ (ofelia with non-zero GHCR pulls)
- [ ] At least one repo shows non-zero watchers
- [ ] "Issues" column displays a larger number than "Issues closed" (open + closed > closed)