### PR TITLE
Drive scope from YAML; drop Lang; add Clones/Views columns

### DIFF
--- a/.github/workflows/impact-dashboard.yml
+++ b/.github/workflows/impact-dashboard.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: '3.14'
 
       - name: Install dependencies
-        run: pip install requests
+        run: pip install requests pyyaml
 
       - name: Collect impact metrics
         env:

--- a/README.md
+++ b/README.md
@@ -68,9 +68,19 @@ Automatically adds new issues and pull requests to the Netresearch TYPO3 project
 
 **File:** `.github/workflows/impact-dashboard.yml`
 
-Collects community-impact metrics for all non-archived `t3x-*` (TYPO3 extensions),
-`*-skill` (Agent Skills), and Go-language repositories in the org, renders a
-static dashboard, and publishes it to the `gh-pages` branch.
+Collects community-impact metrics for repositories listed in
+[`config/dashboard-repos.yaml`](config/dashboard-repos.yaml), renders a static
+dashboard, and publishes it to the `gh-pages` branch.
+
+The config combines two mechanisms:
+
+- **Patterns** auto-include every non-archived public repo whose name matches
+  a prefix/suffix or whose primary language matches a value (today: `t3x-*`,
+  `*-skill`, language `Go`).
+- **`include`** explicitly adds individual repos by name and assigns them to a
+  category. This is how the Commerce, Ansible, and Tools categories are
+  populated. Add or remove entries here in a PR — the workflow picks them up
+  on the next run.
 
 **Schedule:** Daily at 03:00 UTC
 

--- a/config/dashboard-repos.yaml
+++ b/config/dashboard-repos.yaml
@@ -1,0 +1,97 @@
+# Repos covered by the impact dashboard.
+#
+# `patterns` adds every non-archived public repo whose name matches one of the
+# rules. `include` adds specific repos by name (and lets you assign them to a
+# category that wouldn't be picked up by a pattern). A repo can appear in both;
+# the `include` entry's category wins.
+
+patterns:
+  - { match: prefix,   value: "t3x-",   category: typo3-extension }
+  - { match: suffix,   value: "-skill", category: skill }
+  - { match: language, value: "Go",     category: go-project }
+
+# Pretty labels and per-category UI metadata used by the dashboard.
+categories:
+  typo3-extension: { label: "TYPO3 extensions",       pill: typo3 }
+  skill:           { label: "Agent Skills",           pill: skill }
+  go-project:      { label: "Go projects",            pill: go }
+  commerce:        { label: "Commerce integrations",  pill: commerce }
+  ansible:         { label: "Ansible roles",          pill: ansible }
+  tool:            { label: "Tools & libraries",      pill: tool }
+
+include:
+  # ---- Commerce: DHL ----
+  - { name: dhl-lib-shipping-mx,                         category: commerce }
+  - { name: dhl-module-carrier-ecom-us,                  category: commerce }
+  - { name: dhl-module-carrier-paket,                    category: commerce }
+  - { name: dhl-module-carrier-paket-returns,            category: commerce }
+  - { name: dhl-module-carrier-update,                   category: commerce }
+  - { name: dhl-module-label-status-m2,                  category: commerce }
+  - { name: dhl-module-shipping-core,                    category: commerce }
+  - { name: dhl-module-shipping-m2,                      category: commerce }
+  - { name: dhl-module-ui,                               category: commerce }
+  - { name: dhl-module-unified-tracking,                 category: commerce }
+  - { name: dhl-module-versenden-m1,                     category: commerce }
+  - { name: dhl-online-retoure-m1,                       category: commerce }
+  - { name: dhl-sdk-api-bcs,                             category: commerce }
+  - { name: dhl-sdk-api-bcs-returns,                     category: commerce }
+  - { name: dhl-sdk-api-location-finder,                 category: commerce }
+  - { name: dhl-sdk-api-parcel-de,                       category: commerce }
+  - { name: dhl-sdk-api-parcel-de-returns,               category: commerce }
+  - { name: dhl-sdk-api-parcel-management,               category: commerce }
+  - { name: dhl-sdk-api-unified-location-finder,         category: commerce }
+  - { name: dhl-sdk-api-unified-tracking,                category: commerce }
+  - { name: dhl-shipping-m2,                             category: commerce }
+  - { name: module-admin-notification-feed,              category: commerce }
+  - { name: module-interactive-batch-processing,         category: commerce }
+  - { name: module-shipping-core,                        category: commerce }
+  - { name: module-shipping-dispatch,                    category: commerce }
+  - { name: module-shipping-inventory,                   category: commerce }
+  - { name: module-shipping-ui,                          category: commerce }
+
+  # ---- Commerce: Deutsche Post ----
+  - { name: deutschepost-module-addressfactory-m1,       category: commerce }
+  - { name: deutschepost-module-addressfactory-m2,       category: commerce }
+  - { name: deutschepost-module-addressfactory-sw6,      category: commerce }
+  - { name: deutschepost-module-autocomplete-m1,         category: commerce }
+  - { name: deutschepost-module-autocomplete-m2,         category: commerce }
+  - { name: deutschepost-module-autocomplete-sw6,        category: commerce }
+  - { name: deutschepost-module-core,                    category: commerce }
+  - { name: deutschepost-module-internetmarke,           category: commerce }
+  - { name: deutschepost-sdk-addressfactory,             category: commerce }
+  - { name: deutschepost-sdk-api-internetmarke,          category: commerce }
+  - { name: deutschepost-sdk-api-prodws,                 category: commerce }
+  - { name: deutschepost-sdk-autocomplete-authentication, category: commerce }
+
+  # ---- Commerce: Postdirekt + standalone SDKs + Magento utilities ----
+  - { name: postdirekt-autocomplete-monorepo,            category: commerce }
+  - { name: sdk-api-central-station,                     category: commerce }
+  - { name: sdk-api-universal-messenger,                 category: commerce }
+  - { name: sdk-eu-vat,                                  category: commerce }
+  - { name: config-fields-m2,                            category: commerce }
+  - { name: magento2-patches,                            category: commerce }
+  - { name: node-magento-eqp,                            category: commerce }
+  - { name: node-red-contrib-magento-eqp,                category: commerce }
+  - { name: oro-hide-unavailable-variants,               category: commerce }
+  - { name: timalytics,                                  category: commerce }
+
+  # ---- Ansible roles & collections ----
+  - { name: ansible-certificates-from-vault,             category: ansible }
+  - { name: ansible-collection-mautic,                   category: ansible }
+  - { name: ansible-role-gitlab-runner,                  category: ansible }
+  - { name: ansible-role-monitoring-client,              category: ansible }
+  - { name: ansible-role-monitoring-server,              category: ansible }
+  - { name: ansible_role_client_base,                    category: ansible }
+  - { name: ansible_role_docker_containers,              category: ansible }
+
+  # ---- Tools & libraries (the strong-pick set) ----
+  - { name: composer-patches-plugin,                     category: tool }
+  - { name: composer-agent-skill-plugin,                 category: tool }
+  - { name: claude-code-marketplace,                     category: tool }
+  - { name: claude-coach-plugin,                         category: tool }
+  - { name: assetpicker,                                 category: tool }
+  - { name: timetracker,                                 category: tool }
+  - { name: timetracker-ui,                              category: tool }
+  - { name: jira-export,                                 category: tool }
+  - { name: jira-to-openproject,                         category: tool }
+  - { name: deploy-rst,                                  category: tool }

--- a/dashboard/assets/dashboard.js
+++ b/dashboard/assets/dashboard.js
@@ -1,7 +1,7 @@
 (() => {
   'use strict';
 
-  const state = { scope: 'lifetime', snapshot: null, history: null, sortKey: 'stars', sortDir: -1 };
+  const state = { scope: 'lifetime', snapshot: null, history: null, sortKey: 'stars', sortDir: -1, categoryFilter: {} };
 
   const KPI_FIELDS = {
     lifetime: [
@@ -37,13 +37,21 @@
     return String(s ?? '').replace(/[&<>"']/g, c => ESC_MAP[c]);
   }
 
-  const CATEGORY_META = {
-    'typo3-extension': { cls: 'typo3', label: 'TYPO3' },
-    'skill': { cls: 'skill', label: 'Skill' },
-    'go-project': { cls: 'go', label: 'Go' },
+  // Filled from snapshot.categories at load time; exposes both the long label
+  // (used in cards / filter checkboxes) and a short pill label.
+  const SHORT_LABELS = {
+    'typo3-extension': 'TYPO3',
+    'skill': 'Skill',
+    'go-project': 'Go',
+    'commerce': 'Commerce',
+    'ansible': 'Ansible',
+    'tool': 'Tool',
   };
-  function categoryPillClass(cat) { return (CATEGORY_META[cat] || { cls: '' }).cls; }
-  function categoryPillLabel(cat) { return (CATEGORY_META[cat] || { label: cat || '?' }).label; }
+  let CATEGORY_META = {};
+
+  function categoryPillClass(cat) { return (CATEGORY_META[cat] || {}).pill || ''; }
+  function categoryPillLabel(cat) { return SHORT_LABELS[cat] || cat || '?'; }
+  function categoryFullLabel(cat) { return (CATEGORY_META[cat] || {}).label || cat; }
 
   async function loadJSON(path) {
     const res = await fetch(path, { cache: 'no-cache' });
@@ -64,12 +72,23 @@
       return;
     }
 
+    CATEGORY_META = state.snapshot.categories || {};
+    Object.keys(CATEGORY_META).forEach(k => { state.categoryFilter[k] = true; });
+
     renderMeta();
+    renderCategoryFilters();
     renderKPIs();
     renderCategoryCards();
     renderCharts();
     renderTable();
     attachHandlers();
+  }
+
+  function renderCategoryFilters() {
+    const el = document.getElementById('category-filters');
+    el.innerHTML = Object.keys(CATEGORY_META).map(k => `
+      <label><input type="checkbox" data-cat="${esc(k)}" ${state.categoryFilter[k] ? 'checked' : ''}>
+        ${esc(categoryFullLabel(k))}</label>`).join(' ');
   }
 
   function renderMeta() {
@@ -92,11 +111,11 @@
   }
 
   function renderCategoryCards() {
-    const groups = [
-      { key: 'typo3-extension', title: 'TYPO3 extensions', cls: 'typo3' },
-      { key: 'skill', title: 'Skills', cls: 'skill' },
-      { key: 'go-project', title: 'Go projects', cls: 'go' },
-    ];
+    const groups = Object.keys(CATEGORY_META).map(k => ({
+      key: k,
+      title: categoryFullLabel(k),
+      cls: categoryPillClass(k),
+    }));
 
     function card(title, cls, repos) {
       const sum = (path) => repos.reduce((acc, r) => acc + (r[path[0]]?.[path[1]] ?? 0), 0);
@@ -175,14 +194,9 @@
   function renderTable() {
     const tbody = document.querySelector('#repo-table tbody');
     const filter = document.getElementById('repo-filter').value.toLowerCase();
-    const showT3x = document.getElementById('filter-t3x').checked;
-    const showSkill = document.getElementById('filter-skill').checked;
-    const showGo = document.getElementById('filter-go').checked;
 
     let rows = state.snapshot.repos.filter(r => {
-      if (r.category === 'typo3-extension' && !showT3x) return false;
-      if (r.category === 'skill' && !showSkill) return false;
-      if (r.category === 'go-project' && !showGo) return false;
+      if (state.categoryFilter[r.category] === false) return false;
       if (filter && !r.name.toLowerCase().includes(filter) && !(r.description || '').toLowerCase().includes(filter)) return false;
       return true;
     });
@@ -190,26 +204,34 @@
     rows.sort((a, b) => {
       const k = state.sortKey;
       let va, vb;
-      if (k === 'name' || k === 'language') {
-        va = (a[k] || '').toString(); vb = (b[k] || '').toString();
-        return state.sortDir * va.localeCompare(vb);
+      if (k === 'name') {
+        return state.sortDir * (a.name || '').localeCompare(b.name || '');
       }
       const issuesTotal = (r) => (r.lifetime?.issues_open ?? 0) + (r.lifetime?.issues_closed ?? 0);
       if (k === 'commits_30d') { va = a.recent_30d?.commits ?? 0; vb = b.recent_30d?.commits ?? 0; }
       else if (k === 'blast_radius') { va = a.blast_radius ?? 0; vb = b.blast_radius ?? 0; }
       else if (k === 'dependents_repos') { va = a.lifetime?.dependents_repos ?? 0; vb = b.lifetime?.dependents_repos ?? 0; }
       else if (k === 'issues_total') { va = issuesTotal(a); vb = issuesTotal(b); }
+      else if (k === 'clones_14d') { va = a.traffic_14d?.clones_total ?? 0; vb = b.traffic_14d?.clones_total ?? 0; }
+      else if (k === 'views_14d')  { va = a.traffic_14d?.views_total  ?? 0; vb = b.traffic_14d?.views_total  ?? 0; }
       else { va = a.lifetime?.[k] ?? 0; vb = b.lifetime?.[k] ?? 0; }
       return state.sortDir * (va - vb);
     });
 
-    tbody.innerHTML = rows.map(r => `
+    tbody.innerHTML = rows.map(r => {
+      const t = r.traffic_14d;
+      const clonesCell = t
+        ? `<td class="num" title="total: ${fmt(t.clones_total)} · unique: ${fmt(t.clones_unique)}">${fmt(t.clones_total)}<span class="muted"> / ${fmt(t.clones_unique)}</span></td>`
+        : `<td class="num muted">—</td>`;
+      const viewsCell = t
+        ? `<td class="num" title="total: ${fmt(t.views_total)} · unique: ${fmt(t.views_unique)}">${fmt(t.views_total)}<span class="muted"> / ${fmt(t.views_unique)}</span></td>`
+        : `<td class="num muted">—</td>`;
+      return `
       <tr data-name="${esc(r.name)}">
         <td>
           <a href="${esc(r.url)}" target="_blank" rel="noopener">${esc(r.name)}</a>
-          <span class="pill ${categoryPillClass(r.category)}">${categoryPillLabel(r.category)}</span>
+          <span class="pill ${categoryPillClass(r.category)}">${esc(categoryPillLabel(r.category))}</span>
         </td>
-        <td>${esc(r.language || '—')}</td>
         <td class="num">${fmt(r.lifetime.stars)}</td>
         <td class="num">${fmt(r.lifetime.forks)}</td>
         <td class="num">${fmt(r.lifetime.contributors)}</td>
@@ -221,8 +243,11 @@
         <td class="num">${fmt(r.lifetime.packagist_downloads)}</td>
         <td class="num">${fmt(r.lifetime.ghcr_downloads)}</td>
         <td class="num">${fmt(r.lifetime.dependents_repos)}</td>
+        ${clonesCell}
+        ${viewsCell}
         <td class="num">${fmt(r.blast_radius)}</td>
-      </tr>`).join('');
+      </tr>`;
+    }).join('');
   }
 
   function renderDetail(name) {
@@ -315,9 +340,12 @@
     });
 
     document.getElementById('repo-filter').addEventListener('input', renderTable);
-    document.getElementById('filter-t3x').addEventListener('change', renderTable);
-    document.getElementById('filter-skill').addEventListener('change', renderTable);
-    document.getElementById('filter-go').addEventListener('change', renderTable);
+    document.getElementById('category-filters').addEventListener('change', (e) => {
+      const cat = e.target?.dataset?.cat;
+      if (!cat) return;
+      state.categoryFilter[cat] = e.target.checked;
+      renderTable();
+    });
 
     document.querySelector('#repo-table tbody').addEventListener('click', (e) => {
       const tr = e.target.closest('tr[data-name]');

--- a/dashboard/assets/styles.css
+++ b/dashboard/assets/styles.css
@@ -202,9 +202,14 @@ tbody tr { cursor: pointer; }
   letter-spacing: .04em;
 }
 
-.pill.typo3 { background: rgba(47, 153, 164, 0.18); color: var(--nr-teal); }
-.pill.skill { background: rgba(255, 77, 0, 0.18); color: var(--nr-orange); }
-.pill.go { background: rgba(0, 173, 216, 0.18); color: #00ADD8; }
+.pill.typo3    { background: rgba(47, 153, 164, 0.18); color: var(--nr-teal); }
+.pill.skill    { background: rgba(255, 77, 0, 0.18);   color: var(--nr-orange); }
+.pill.go       { background: rgba(0, 173, 216, 0.18);  color: #00ADD8; }
+.pill.commerce { background: rgba(255, 193, 7, 0.18);  color: #FFC107; }
+.pill.ansible  { background: rgba(238, 0, 0, 0.18);    color: #EE0000; }
+.pill.tool     { background: rgba(154, 160, 166, 0.22); color: var(--fg-muted); }
+
+.muted { color: var(--fg-muted); }
 
 #repo-detail {
   margin-top: 2rem;

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -10,7 +10,7 @@
   <header class="site-header">
     <div class="container">
       <h1>Netresearch Open Source Impact</h1>
-      <p class="subtitle">TYPO3 extensions, AI agent skills &amp; Go projects on <a href="https://github.com/netresearch">github.com/netresearch</a></p>
+      <p class="subtitle">Open-source impact across <a href="https://github.com/netresearch">github.com/netresearch</a> — TYPO3 extensions, agent skills, Go projects, commerce integrations, Ansible roles &amp; tools.</p>
       <p id="meta" class="meta">Loading…</p>
     </div>
   </header>
@@ -40,16 +40,13 @@
       <h2>Repositories</h2>
       <div class="filter-bar">
         <input type="search" id="repo-filter" placeholder="Filter repos…" aria-label="Filter repositories">
-        <label><input type="checkbox" id="filter-t3x" checked> TYPO3 extensions</label>
-        <label><input type="checkbox" id="filter-skill" checked> Skills</label>
-        <label><input type="checkbox" id="filter-go" checked> Go projects</label>
+        <span id="category-filters"></span>
       </div>
       <div class="table-wrap">
         <table id="repo-table">
           <thead>
             <tr>
               <th data-sort="name">Repo</th>
-              <th data-sort="language">Lang</th>
               <th data-sort="stars" class="num">★</th>
               <th data-sort="forks" class="num">Forks</th>
               <th data-sort="contributors" class="num">Contrib.</th>
@@ -61,6 +58,8 @@
               <th data-sort="packagist_downloads" class="num">Packagist</th>
               <th data-sort="ghcr_downloads" class="num">GHCR</th>
               <th data-sort="dependents_repos" class="num">Used by</th>
+              <th data-sort="clones_14d" class="num" title="Last 14 days · total / unique on hover">Clones 14d</th>
+              <th data-sort="views_14d" class="num" title="Last 14 days · total / unique on hover">Views 14d</th>
               <th data-sort="blast_radius" class="num">Blast radius</th>
             </tr>
           </thead>

--- a/scripts/collect_impact.py
+++ b/scripts/collect_impact.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from urllib.parse import quote
 
 import requests
+import yaml
 
 GITHUB_API = "https://api.github.com"
 GITHUB_WEB = "https://github.com"
@@ -33,6 +34,11 @@ CORE_TOKEN = os.environ["GITHUB_TOKEN"]
 TRAFFIC_TOKEN = os.environ.get("IMPACT_DASHBOARD_PAT") or None
 SCRAPE_UA = "netresearch-impact-dashboard/1.0 (+https://github.com/netresearch/maint)"
 SCRAPE_HEADERS = {"User-Agent": SCRAPE_UA, "Accept": "text/html"}
+
+CONFIG_PATH = Path(os.environ.get(
+    "DASHBOARD_CONFIG",
+    Path(__file__).resolve().parent.parent / "config" / "dashboard-repos.yaml",
+))
 
 NOW = datetime.now(timezone.utc)
 TODAY = NOW.date().isoformat()
@@ -114,30 +120,72 @@ def count_commits_since(full_name: str, since_iso: str | None = None) -> int:
 # ---- repo discovery -------------------------------------------------------
 
 
-def classify(repo: dict) -> str | None:
+def load_config(path: Path = CONFIG_PATH) -> dict:
+    """Read the YAML allow-list/category config."""
+    with path.open() as fh:
+        cfg = yaml.safe_load(fh) or {}
+    cfg.setdefault("patterns", [])
+    cfg.setdefault("include", [])
+    cfg.setdefault("categories", {})
+    return cfg
+
+
+def classify(repo: dict, cfg: dict) -> str | None:
+    """Return the category for a repo, or None if it shouldn't be included.
+
+    Explicit `include` entries take precedence over `patterns`.
+    """
     name = repo.get("name", "")
-    if name.startswith("t3x-"):
-        return "typo3-extension"
-    if name.endswith("-skill"):
-        return "skill"
-    if repo.get("language") == "Go":
-        return "go-project"
+    for entry in cfg["include"]:
+        if entry.get("name") == name:
+            return entry.get("category")
+    for pat in cfg["patterns"]:
+        match = pat.get("match")
+        value = pat.get("value")
+        if match == "prefix" and name.startswith(value):
+            return pat.get("category")
+        if match == "suffix" and name.endswith(value):
+            return pat.get("category")
+        if match == "language" and repo.get("language") == value:
+            return pat.get("category")
     return None
 
 
-def list_target_repos() -> list[dict]:
+def list_target_repos(cfg: dict) -> list[dict]:
+    """List public repos that either match a pattern or are explicitly included.
+
+    Repos in `include` that aren't in the org's public list (deleted/private/
+    archived) are quietly skipped after one extra GET attempt.
+    """
     repos = gh_get_all(f"{GITHUB_API}/orgs/{ORG_NAME}/repos?type=public&per_page=100")
-    selected = []
-    for r in repos:
-        if r.get("archived") or r.get("private"):
-            continue
-        category = classify(r)
+    by_name = {r["name"]: r for r in repos if not (r.get("archived") or r.get("private"))}
+
+    selected: dict[str, dict] = {}
+    for r in by_name.values():
+        category = classify(r, cfg)
         if category is None:
             continue
         r["_category"] = category
-        selected.append(r)
-    selected.sort(key=lambda r: r["name"])
-    return selected
+        selected[r["name"]] = r
+
+    explicit_names = {e["name"] for e in cfg["include"] if "name" in e}
+    for name in explicit_names - selected.keys():
+        try:
+            r = gh_get(f"{GITHUB_API}/repos/{ORG_NAME}/{name}").json()
+        except requests.HTTPError as e:
+            status = e.response.status_code if e.response is not None else "?"
+            print(f"  config repo {name}: not reachable (HTTP {status}), skipping", file=sys.stderr)
+            continue
+        if r.get("archived") or r.get("private"):
+            print(f"  config repo {name}: archived/private, skipping", file=sys.stderr)
+            continue
+        cat = classify(r, cfg)
+        if cat is None:
+            continue
+        r["_category"] = cat
+        selected[name] = r
+
+    return sorted(selected.values(), key=lambda r: r["name"])
 
 
 def list_public_members() -> set[str]:
@@ -573,9 +621,12 @@ def copy_dashboard_assets(base: Path) -> None:
 def main() -> int:
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
+    print(f"Loading config from {CONFIG_PATH}", file=sys.stderr)
+    cfg = load_config()
+
     print(f"Scanning {ORG_NAME} for matching repos...", file=sys.stderr)
-    repos = list_target_repos()
-    print(f"Found {len(repos)} repos (t3x-* + *-skill, non-archived).", file=sys.stderr)
+    repos = list_target_repos(cfg)
+    print(f"Found {len(repos)} repos in dashboard scope.", file=sys.stderr)
 
     print("Loading org public members...", file=sys.stderr)
     members = list_public_members()
@@ -597,6 +648,7 @@ def main() -> int:
         "generated_at": NOW.isoformat(timespec="seconds"),
         "org": ORG_NAME,
         "traffic_available": TRAFFIC_TOKEN is not None,
+        "categories": cfg["categories"],
         "totals": aggregate_totals(collected),
         "repos": collected,
     }


### PR DESCRIPTION
## Summary

### Scope expansion (61 → ~127 repos)

`config/dashboard-repos.yaml` is now the single source of truth for which repos go in the dashboard. It combines:

- **Patterns**: `t3x-*` → typo3-extension, `*-skill` → skill, `language: Go` → go-project (unchanged).
- **`include`**: explicit per-name additions assigned to a category.

Three new categories filled in via `include`:

| Category | Repos | Why included |
|---|---:|---|
| `commerce` | ~49 | Full DHL / Deutsche Post / Postdirekt cluster + standalone SDKs + Magento utilities. Most are PHP modules on Packagist with real download volume. `dhl-module-shipping-m2` (32★/19 forks) is the flagship. |
| `ansible` | 7 | Publicly distributed Ansible roles & collections (`ansible-certificates-from-vault` 8★, `ansible-role-monitoring-server` 3★, etc.). Reversed my earlier "internal" call — these are Galaxy-distributed. |
| `tool` | 10 | `composer-patches-plugin` (80★ — biggest non-tracked repo in the org), `claude-code-marketplace` (30★), `timetracker`/`timetracker-ui` (24★), `assetpicker` (22★), `jira-export`, `jira-to-openproject`, `claude-coach-plugin`, `deploy-rst`, `composer-agent-skill-plugin`. |

`jira-to-openproject` is in `tool`. Forks, infra (`docker-*`), and meta repos (`.github`, `maint`, `netresearch.github.io`, `renovate-config`) remain excluded — easy to flip later by editing the YAML.

### Dashboard UI

- **Drop Lang column** — superfluous, language is still in the per-repo JSON for anyone who wants it.
- **Add Clones (14d) and Views (14d)** — sourced from existing `traffic_14d`; each cell shows `total / unique` with a tooltip and sorts by `total`. Repos with no traffic data show `—`.
- **Filter checkboxes and category cards now render dynamically from `snapshot.categories`**. Adding a new category in the YAML lights up automatically next run with no JS edit.
- New pill colors: `commerce` (gold), `ansible` (red), `tool` (gray).

### Other

- Workflow installs `pyyaml`.
- Repos listed in `include` but missing from the org's public list get one extra GET attempt before being skipped, so config drift surfaces in the log instead of silently dropping entries.

## Test plan

- [x] Python + JS syntax checks
- [x] Local config-loader test (66 explicit + 3 patterns; classify maps each category correctly)
- [ ] Workflow run completes end-to-end against ~127 repos
- [ ] Live dashboard at https://netresearch.github.io/maint/ shows 6 category cards, 6 filter checkboxes, Clones/Views columns populated, no Lang column