### PR TITLE
feat(dashboard): count archived repos in growth charts, hide from table

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ dashboard, and publishes it to the `gh-pages` branch.
 
 The config combines two mechanisms:
 
-- **Patterns** auto-include every non-archived public repo whose name matches
+- **Patterns** auto-include every public repo (archived included) whose name matches
   a prefix/suffix or whose primary language matches a value (today: `t3x-*`,
   `*-skill`, language `Go`).
 - **`include`** explicitly adds individual repos by name and assigns them to a

--- a/dashboard/assets/dashboard.js
+++ b/dashboard/assets/dashboard.js
@@ -95,8 +95,11 @@
     const s = state.snapshot;
     const ts = new Date(s.generated_at).toLocaleString();
     const traffic = s.traffic_available ? 'traffic enabled' : 'traffic disabled (no PAT)';
+    const archived = s.repos.filter(r => r.archived).length;
+    const active = s.repos.length - archived;
+    const repoLabel = archived ? `${active} active repos (+${archived} archived)` : `${active} repos`;
     document.getElementById('meta').textContent =
-      `${s.repos.length} repos · last updated ${ts} · ${traffic}`;
+      `${repoLabel} · last updated ${ts} · ${traffic}`;
   }
 
   function renderKPIs() {
@@ -196,6 +199,7 @@
     const filter = document.getElementById('repo-filter').value.toLowerCase();
 
     let rows = state.snapshot.repos.filter(r => {
+      if (r.archived) return false;
       if (state.categoryFilter[r.category] === false) return false;
       if (filter && !r.name.toLowerCase().includes(filter) && !(r.description || '').toLowerCase().includes(filter)) return false;
       return true;

--- a/scripts/backfill_archived_history.py
+++ b/scripts/backfill_archived_history.py
@@ -36,6 +36,8 @@ import json
 import sys
 from pathlib import Path
 
+import requests
+
 from collect_impact import (
     OUTPUT_DIR,
     aggregate_totals,
@@ -50,6 +52,10 @@ from collect_impact import (
 # count handled separately (per-day membership), so it is added on its own.
 _SKIP_TOTALS_KEYS = {"repos"}
 
+# Per-date set of repo names, populated by last_seen_records() and reused by
+# load_snapshot_names() so each snapshot file is read and parsed only once.
+_SNAPSHOT_NAMES: dict[str, set[str]] = {}
+
 
 def repo_contribution(record: dict) -> dict:
     """Return the totals a single repo contributes to aggregate_totals()."""
@@ -58,18 +64,32 @@ def repo_contribution(record: dict) -> dict:
 
 
 def load_snapshot_names(base: Path, date: str) -> set[str] | None:
-    """Repo names present in the snapshot for ``date`` (None if it is missing)."""
+    """Repo names present in the snapshot for ``date`` (None if it is missing).
+
+    Served from the cache populated by last_seen_records(); only dates with no
+    snapshot file fall through to a disk check.
+    """
+    if date in _SNAPSHOT_NAMES:
+        return _SNAPSHOT_NAMES[date]
     path = base / "data" / "snapshots" / f"{date}.json"
     if not path.exists():
         return None
-    return {r["name"] for r in json.loads(path.read_text()).get("repos", [])}
+    names = {r["name"] for r in json.loads(path.read_text()).get("repos", [])}
+    _SNAPSHOT_NAMES[date] = names
+    return names
 
 
 def last_seen_records(base: Path) -> dict[str, dict]:
-    """Each repo's record from the most recent daily snapshot it appeared in."""
+    """Each repo's record from the most recent daily snapshot it appeared in.
+
+    Also fills _SNAPSHOT_NAMES so load_snapshot_names() avoids re-reading the
+    same files during the per-day pass.
+    """
     seen: dict[str, dict] = {}
     for path in sorted((base / "data" / "snapshots").glob("*.json")):  # latest wins
-        for repo in json.loads(path.read_text()).get("repos", []):
+        repos = json.loads(path.read_text()).get("repos", [])
+        _SNAPSHOT_NAMES[path.stem] = {r["name"] for r in repos}
+        for repo in repos:
             seen[repo["name"]] = repo
     return seen
 
@@ -115,7 +135,14 @@ def main() -> int:
             members = list_public_members()
             containers = list_org_containers()
             for repo in need_fresh:
-                record = collect_repo(repo, members, containers)
+                try:
+                    record = collect_repo(repo, members, containers)
+                except requests.RequestException as e:
+                    # One unreachable repo (deleted, transient error) must not
+                    # abort the whole backfill. Log the type only -- never the
+                    # exception object, which can carry tokens in the URL.
+                    print(f"  ERROR collecting {repo['name']}: {type(e).__name__}, skipping", file=sys.stderr)
+                    continue
                 record["archived"] = True
                 contributions[repo["name"]] = repo_contribution(record)
         else:

--- a/scripts/backfill_archived_history.py
+++ b/scripts/backfill_archived_history.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""One-time backfill: fold archived repos into the historical daily totals.
+
+Until now ``collect_impact.py`` excluded archived repos, so the day a repo was
+archived it dropped out of ``data/history.json``'s daily ``totals`` (and repos
+that were already archived before the dashboard started were never counted at
+all). On the "Growth over time" chart that shows up as sudden downward steps,
+even though no stars/forks/contributors were actually lost.
+
+``collect_impact.py`` now keeps archived repos in the totals going forward.
+This script repairs the *existing* history so the line is continuous instead of
+dipping. For every daily entry it adds the contribution of each in-scope
+archived repo that was **not already counted that day**, so repos that were
+still active earlier in the window are never double-counted.
+
+Per-day membership is read from ``data/snapshots/<date>.json``. The frozen
+metric values come from the last daily snapshot the repo appeared in -- so for
+a repo archived mid-window the backfilled value equals what was counted the day
+before it was archived, and the archive boundary cancels with no residual step.
+Repos archived before the dashboard existed never appear in any snapshot; their
+values are collected once from the GitHub API (set ``--no-api`` to skip them,
+which leaves them out of history -- the collector will then introduce a small
+one-time step on its next run instead).
+
+Run once against a gh-pages checkout, then commit the updated history.json
+(OUTPUT_DIR is the same env var collect_impact.py uses for its build dir):
+
+    OUTPUT_DIR=/path/to/gh-pages-checkout GITHUB_TOKEN=... \
+        python scripts/backfill_archived_history.py
+
+Pass ``--dry-run`` to print the corrected totals without writing.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from collect_impact import (
+    OUTPUT_DIR,
+    aggregate_totals,
+    collect_repo,
+    list_org_containers,
+    list_public_members,
+    list_target_repos,
+    load_config,
+)
+
+# Keys in aggregate_totals() that are summed across repos. "repos" is a member
+# count handled separately (per-day membership), so it is added on its own.
+_SKIP_TOTALS_KEYS = {"repos"}
+
+
+def repo_contribution(record: dict) -> dict:
+    """Return the totals a single repo contributes to aggregate_totals()."""
+    totals = aggregate_totals([record])
+    return {k: v for k, v in totals.items() if k not in _SKIP_TOTALS_KEYS}
+
+
+def load_snapshot_names(base: Path, date: str) -> set[str] | None:
+    """Repo names present in the snapshot for ``date`` (None if it is missing)."""
+    path = base / "data" / "snapshots" / f"{date}.json"
+    if not path.exists():
+        return None
+    return {r["name"] for r in json.loads(path.read_text()).get("repos", [])}
+
+
+def last_seen_records(base: Path) -> dict[str, dict]:
+    """Each repo's record from the most recent daily snapshot it appeared in."""
+    seen: dict[str, dict] = {}
+    for path in sorted((base / "data" / "snapshots").glob("*.json")):  # latest wins
+        for repo in json.loads(path.read_text()).get("repos", []):
+            seen[repo["name"]] = repo
+    return seen
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    dry_run = "--dry-run" in args
+    use_api = "--no-api" not in args
+    base = OUTPUT_DIR
+
+    history_path = base / "data" / "history.json"
+    if not history_path.exists():
+        print(f"No history at {history_path}", file=sys.stderr)
+        return 1
+    history = json.loads(history_path.read_text())
+    daily = history.get("daily", [])
+    if not daily:
+        print("History has no daily entries; nothing to backfill.", file=sys.stderr)
+        return 0
+
+    cfg = load_config()
+    print("Listing in-scope repos (archived included)...", file=sys.stderr)
+    archived = [r for r in list_target_repos(cfg) if r.get("archived")]
+    print(f"Found {len(archived)} archived in-scope repos.", file=sys.stderr)
+    if not archived:
+        print("Nothing archived in scope; history unchanged.", file=sys.stderr)
+        return 0
+
+    # Frozen contribution per archived repo: prefer its last snapshot value so
+    # mid-window archive boundaries cancel exactly; only repos that never appear
+    # in any snapshot need a fresh API collection.
+    seen = last_seen_records(base)
+    contributions: dict[str, dict] = {
+        r["name"]: repo_contribution(seen[r["name"]])
+        for r in archived
+        if r["name"] in seen
+    }
+    need_fresh = [r for r in archived if r["name"] not in seen]
+    if need_fresh:
+        names = ", ".join(sorted(r["name"] for r in need_fresh))
+        if use_api:
+            print(f"Collecting {len(need_fresh)} never-seen archived repos from API: {names}", file=sys.stderr)
+            members = list_public_members()
+            containers = list_org_containers()
+            for repo in need_fresh:
+                record = collect_repo(repo, members, containers)
+                record["archived"] = True
+                contributions[repo["name"]] = repo_contribution(record)
+        else:
+            print(f"--no-api: leaving {len(need_fresh)} never-seen archived repos OUT of history: {names}", file=sys.stderr)
+
+    changed = 0
+    for entry in daily:
+        totals = entry.setdefault("totals", {})
+        present = load_snapshot_names(base, entry["date"])
+        for name, contribution in contributions.items():
+            if present is not None and name in present:
+                continue  # already counted that day -> no double-count
+            for key, value in contribution.items():
+                totals[key] = totals.get(key, 0) + value
+            totals["repos"] = totals.get("repos", 0) + 1
+            changed += 1
+
+    print(
+        f"Backfilled {len(contributions)} archived repos across {len(daily)} days "
+        f"({changed} repo-day additions).",
+        file=sys.stderr,
+    )
+    print(json.dumps(daily[-1]["totals"], indent=2))
+
+    if dry_run:
+        print("--dry-run: history.json not written.", file=sys.stderr)
+        return 0
+
+    history["daily"] = daily
+    history_path.write_text(json.dumps(history, indent=2))
+    print(f"Wrote {history_path}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/collect_impact.py
+++ b/scripts/collect_impact.py
@@ -154,11 +154,13 @@ def classify(repo: dict, cfg: dict) -> str | None:
 def list_target_repos(cfg: dict) -> list[dict]:
     """List public repos that either match a pattern or are explicitly included.
 
-    Repos in `include` that aren't in the org's public list (deleted/private/
-    archived) are quietly skipped after one extra GET attempt.
+    Archived repos are kept (they still count toward the lifetime totals and
+    growth charts); the dashboard hides them from the active repository table.
+    Private repos are excluded. Repos in `include` that aren't in the org's
+    public list (deleted/private) are quietly skipped after one extra GET attempt.
     """
     repos = gh_get_all(f"{GITHUB_API}/orgs/{ORG_NAME}/repos?type=public&per_page=100")
-    by_name = {r["name"]: r for r in repos if not (r.get("archived") or r.get("private"))}
+    by_name = {r["name"]: r for r in repos if not r.get("private")}
 
     selected: dict[str, dict] = {}
     for r in by_name.values():
@@ -176,8 +178,8 @@ def list_target_repos(cfg: dict) -> list[dict]:
             status = e.response.status_code if e.response is not None else "?"
             print(f"  config repo {name}: not reachable (HTTP {status}), skipping", file=sys.stderr)
             continue
-        if r.get("archived") or r.get("private"):
-            print(f"  config repo {name}: archived/private, skipping", file=sys.stderr)
+        if r.get("private"):
+            print(f"  config repo {name}: private, skipping", file=sys.stderr)
             continue
         cat = classify(r, cfg)
         if cat is None:
@@ -639,7 +641,9 @@ def main() -> int:
     collected: list[dict] = []
     for repo in repos:
         try:
-            collected.append(collect_repo(repo, members, containers))
+            record = collect_repo(repo, members, containers)
+            record["archived"] = bool(repo.get("archived"))
+            collected.append(record)
         except requests.HTTPError as e:
             status = e.response.status_code if e.response is not None else "?"
             print(f"  ERROR {repo['name']}: HTTP {status}", file=sys.stderr)


### PR DESCRIPTION
## Why

The "Growth over time" chart showed sudden downward steps — e.g. 2026-05-22, 05-27, 05-29 — even though no stars/forks/contributors were ever lost. Root cause: archived repos were excluded from collection entirely, so the day a repo was archived it dropped out of the aggregate `totals`, and repos archived before the dashboard existed were never counted at all. The "cumulative" line is really a daily re-sum across the tracked repos, so removing a repo from the set steps the whole line down.

Each big synchronized drop was an archive event: 5 DHL Magento modules archived around 05-22, two legacy `t3x-*` extensions around 05-27, and 2 DHL BCS SDKs around 05-29.

## What changed

**Collector (`scripts/collect_impact.py`)** — archived public repos are now kept in the collected set (private repos are still excluded) and each record is tagged `archived`. They therefore count toward the lifetime totals, the KPI headline and the category cards automatically (those read `totals` / `repos`).

**Dashboard (`dashboard/assets/dashboard.js`)** — the repository table filters out archived repos, so it still lists only active repos. The meta line now reports the split, e.g. `113 active repos (+28 archived)`.

**Config + README** — wording updated to reflect that archived repos are included in the metrics but hidden from the table; private repos remain excluded.

This brings 28 archived in-scope repos into the metrics — mostly archived DHL / Deutsche Post commerce modules and legacy `t3x-*` extensions, plus `udp-proxy`.

## Backfill (`scripts/backfill_archived_history.py`)

The collector change is forward-looking; the existing `history.json` still holds the pre-fix dips. The one-time backfill repairs them: for each daily entry it adds the contribution of every in-scope archived repo that was **not already counted that day**, using the repo's **last-seen snapshot value** (12 repos archived mid-window) or a **fresh API collection** (16 repos archived before the dashboard existed) so archive boundaries cancel with no residual step.

It operates on `gh-pages` data, so run it once **after this is merged** (`OUTPUT_DIR` is the same env var `collect_impact.py` uses):

```
OUTPUT_DIR=/path/to/gh-pages-checkout GITHUB_TOKEN=... \
    python scripts/backfill_archived_history.py
```

then commit the updated `data/history.json` to `gh-pages`. **Ordering matters:** if the backfill is committed while the old (exclude-archived) collector is still live, the next scheduled run would append a fresh dipped day and re-introduce a cliff. Merge this first, then backfill. (`--dry-run` previews; `--no-api` skips the 16 never-seen repos.)

## Verification

Ran the full backfill against a copy of the live `gh-pages` data. Before → after (stars/forks/contributors), abridged around the three drop dates:

```
2026-05-21   920/317/744  ->   983/343/817
2026-05-22   873/287/702  ->   983/343/817   (was -47/-30/-42; now flat)
2026-05-26   885/291/704  ->   995/347/819
2026-05-27   876/291/677  ->   995/347/819   (was -9/0/-27; now flat)
2026-05-28   884/291/679  ->  1003/347/821
2026-05-29   876/268/667  ->  1003/347/821   (was -8/-23/-12; now flat)
2026-05-30   878/269/668  ->  1005/348/822
```

All three big synchronized drops are eliminated; the line climbs smoothly from 501 (first partial run) to 1005. The only remaining dips are two genuine −1 changes (a real unstar on 04-25, a real fork deletion on 05-07), which are correct to keep. The per-day correction grows over time because early in the window many now-archived repos were still active and present in the snapshot (so not re-added) — the backfill only fills the gap once they actually drop out.

## Notes

- **No snapshot corruption.** While investigating I briefly suspected the `data/snapshots/*.json` files were inconsistent; on a clean re-check they match `history.totals` exactly on every date, so there is nothing to fix there.
- The `impact-dashboard.yml` "Checkout existing gh-pages (best effort)" step uses `continue-on-error: true`. It is not causing data loss today, but if that checkout ever failed the build would start from empty and lose history — worth hardening in a follow-up (out of scope here).
- Commits are signed-off (DCO) but not GPG/SSH-signed: no signing key is configured in this environment, and the repo's existing history is unsigned.
