### PR TITLE
fix: authenticate star checks with a collaborator PAT

### DIFF
--- a/.github/workflows/star-notifications.yml
+++ b/.github/workflows/star-notifications.yml
@@ -34,7 +34,11 @@ jobs:
 
       - name: Check for new stars
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Since 2026-06-30 the stargazers and subscribers endpoints are readable
+          # only by a repo's admins/collaborators, which the Actions GITHUB_TOKEN is
+          # not. Needs a fine-grained PAT (Metadata: read) on the netresearch org.
+          # https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/
+          GITHUB_TOKEN: ${{ secrets.STAR_NOTIFICATIONS_PAT }}
           MATRIX_WEBHOOK_URL: ${{ secrets.MATRIX_WEBHOOK_URL }}
           ORG_NAME: netresearch
         run: python scripts/check-stars.py

--- a/scripts/check-stars.py
+++ b/scripts/check-stars.py
@@ -12,7 +12,7 @@ from bs4 import BeautifulSoup
 
 GITHUB_API = "https://api.github.com"
 ORG_NAME = os.environ.get("ORG_NAME", "netresearch")
-GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
 MATRIX_WEBHOOK_URL = os.environ["MATRIX_WEBHOOK_URL"]
 STATE_FILE = Path("state/stars-state.json")
 MAX_NOTIFICATIONS = 20
@@ -31,8 +31,17 @@ class AuthError(Exception):
 
 
 def is_rate_limited(response: requests.Response) -> bool:
-    """Distinguish a rate-limit 403 (transient) from a permission 403 (not)."""
-    return response.headers.get("X-RateLimit-Remaining") == "0"
+    """Distinguish a rate-limit 403 (transient) from a permission 403 (not).
+
+    A primary limit zeroes the budget header. A secondary limit does not, and only
+    sometimes sends Retry-After, so the body is the last resort.
+    https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
+    """
+    if response.headers.get("X-RateLimit-Remaining") == "0":
+        return True
+    if "Retry-After" in response.headers:
+        return True
+    return "secondary rate limit" in response.text.lower()
 
 
 def github_request(url: str, accept: str = "application/vnd.github+json", max_retries: int = 3) -> list | dict:
@@ -57,7 +66,11 @@ def github_request(url: str, accept: str = "application/vnd.github+json", max_re
                     time.sleep(retry_after)
                     continue
                 if response.status_code in (401, 403):
-                    raise AuthError(f"{response.status_code} for {url} - token cannot read this endpoint")
+                    try:
+                        detail = response.json().get("message", response.reason)
+                    except (ValueError, AttributeError):
+                        detail = response.reason
+                    raise AuthError(f"{response.status_code} for {url}: {detail}")
                 response.raise_for_status()
                 data = response.json()
                 if isinstance(data, list):
@@ -305,6 +318,8 @@ def notify_matrix(message: str) -> None:
 
 
 def main():
+    if not GITHUB_TOKEN:
+        raise AuthError("no token in the environment")
     state = load_state()
     repos = get_org_repos()
     is_first_run = not state.get("last_run")

--- a/scripts/check-stars.py
+++ b/scripts/check-stars.py
@@ -22,6 +22,19 @@ FEED_URL = "https://github.com/netresearch/maint/actions/workflows/star-notifica
 _user_cache: dict[str, dict] = {}
 
 
+class AuthError(Exception):
+    """The token may not read an endpoint.
+
+    Systemic rather than per-repo, so it aborts the run instead of letting every
+    repo degrade to "no news" and reporting success.
+    """
+
+
+def is_rate_limited(response: requests.Response) -> bool:
+    """Distinguish a rate-limit 403 (transient) from a permission 403 (not)."""
+    return response.headers.get("X-RateLimit-Remaining") == "0"
+
+
 def github_request(url: str, accept: str = "application/vnd.github+json", max_retries: int = 3) -> list | dict:
     """Make authenticated GitHub API request with retry logic for transient errors."""
     headers = {
@@ -36,11 +49,15 @@ def github_request(url: str, accept: str = "application/vnd.github+json", max_re
             try:
                 response = requests.get(url, headers=headers, timeout=30)
                 # Retry on transient server errors
-                if response.status_code in (429, 502, 503, 504):
+                if response.status_code in (429, 502, 503, 504) or (
+                    response.status_code == 403 and is_rate_limited(response)
+                ):
                     retry_after = int(response.headers.get("Retry-After", 2 ** attempt))
                     print(f"Retry {attempt + 1}/{max_retries}: {response.status_code} for {url}, waiting {retry_after}s")
                     time.sleep(retry_after)
                     continue
+                if response.status_code in (401, 403):
+                    raise AuthError(f"{response.status_code} for {url} - token cannot read this endpoint")
                 response.raise_for_status()
                 data = response.json()
                 if isinstance(data, list):
@@ -51,6 +68,10 @@ def github_request(url: str, accept: str = "application/vnd.github+json", max_re
                 break  # Success, exit retry loop
             except requests.exceptions.RequestException as e:
                 last_error = e
+                # Client errors are the server's final answer, so retrying only burns time
+                status = e.response.status_code if e.response is not None else None
+                if status is not None and 400 <= status < 500:
+                    raise
                 if attempt < max_retries - 1:
                     wait_time = 2 ** attempt
                     print(f"Retry {attempt + 1}/{max_retries}: {e}, waiting {wait_time}s")
@@ -440,4 +461,9 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except AuthError as e:
+        print(f"::error::{e}. Check that STAR_NOTIFICATIONS_PAT is set, unexpired, and grants "
+              f"Metadata: read on the {ORG_NAME} org.")
+        raise SystemExit(1)


### PR DESCRIPTION
## Problem

[Since 2026-06-30](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/) GitHub restricts `/repos/{owner}/{repo}/stargazers` and `/repos/{owner}/{repo}/subscribers` to a repository's admins and collaborators. The Actions `GITHUB_TOKEN` is neither, so all 278 org repos return 403.

Evidence from [run 29356456035](https://github.com/netresearch/maint/actions/runs/29356456035/job/87165211799):

- 278/278 repos 403'd on `stargazers` and `subscribers` — including `netresearch/maint` itself.
- `forks` never failed (0 failures); it is not part of the restriction. This rules out a rate limit or a bad token.
- A collaborator token returns 200 on `netresearch/JCarouselSlider` stargazers and 404 on `torvalds/linux` — the new rule, enforced.

The oldest retained log (2026-07-05) shows the same failure, and `git log` shows no functional change to the script in that window. This broke server-side.

The workflow reported `Found: 0 star(s)` and exited green throughout, which is why it went unnoticed.

## Change

- Read the token from `STAR_NOTIFICATIONS_PAT`. Both endpoints need only **Metadata: read** ([permissions reference](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens)), which every fine-grained PAT carries by default.
- Retry a 403 only when `X-RateLimit-Remaining: 0`. The permission 403s were retried 3x each with backoff, which stretched the job to 37 minutes and 1670 log lines.
- A permission 403 now raises and fails the run rather than degrading every repo to "no news" under a green check.

## Deploy step

Requires the `STAR_NOTIFICATIONS_PAT` secret before merge, or the workflow fails loudly (by design):

1. Fine-grained PAT, resource owner **netresearch**, repository access **All repositories**, permissions: **Metadata: read** (default).
2. `gh secret set STAR_NOTIFICATIONS_PAT --repo netresearch/maint`

The PAT expires and will need rotating; the run turns red with an `::error::` annotation naming the secret when it does.

## Verification

Request paths exercised against the live API:

| Case | Result |
|---|---|
| stargazers, collaborator token | 200, parsed |
| 401 token | `AuthError` propagates out of `get_stargazers`, 0.2s, no retry sleeps |
| 403 with `X-RateLimit-Remaining: 0` | classified transient |
| 403 with budget remaining | classified permission |
| 404 repo | `None` in 0.3s (was ~3s of sleeps) |

Not yet verified end-to-end: the fine-grained PAT itself, which does not exist yet. A `workflow_dispatch` run on this branch after the secret is set will confirm.

## Not addressed

Pre-existing, unrelated to this failure: `datetime.utcnow()` deprecation warning, and `#dependents` scrape warnings on `mqtt-concourse-ws2812b` and `dind`.