### PR TITLE
fix(star-notifications): treat empty repos as zero dependents

### DIFF
--- a/scripts/check-stars.py
+++ b/scripts/check-stars.py
@@ -159,8 +159,9 @@ def get_org_repos() -> list[dict]:
             "stargazers_count": r["stargazers_count"],
             "forks_count": r["forks_count"],
             "watchers_count": r.get("subscribers_count", r.get("watchers_count", 0)),
-            # Empty repos (no commits) have no dependency graph page
-            "is_empty": r.get("size", 0) == 0,
+            # Empty repos (no commits) have no dependency graph page. A missing
+            # size is treated as non-empty so we still scrape rather than skip.
+            "is_empty": r.get("size") == 0,
         }
         for r in repos
         if not r.get("private", False)
@@ -212,6 +213,36 @@ def get_watchers(repo_full_name: str) -> list[dict] | None:
         return None
 
 
+def _parse_dependents(soup: BeautifulSoup) -> list[dict]:
+    """Extract dependent repos from a parsed #dependents page.
+
+    Each Box-row links to a repository; enrich it with star/fork counts via the
+    API, falling back to zeros when that lookup fails.
+    """
+    dependents = []
+    for item in soup.select('.Box-row'):
+        repo_link = item.select_one('a[data-hovercard-type="repository"]')
+        if not repo_link:
+            continue
+        dep_full_name = repo_link.get('href', '').lstrip('/')
+        if not dep_full_name or '/' not in dep_full_name:
+            continue
+        entry = {
+            "full_name": dep_full_name,
+            "url": f"https://github.com/{dep_full_name}",
+            "stars": 0,
+            "forks": 0,
+        }
+        try:
+            repo_info = github_request(f"{GITHUB_API}/repos/{dep_full_name}")
+            entry["stars"] = repo_info.get("stargazers_count", 0)
+            entry["forks"] = repo_info.get("forks_count", 0)
+        except (requests.exceptions.RequestException, KeyError, ValueError) as e:
+            print(f"Warning: Could not get info for dependent {dep_full_name}: {e}")
+        dependents.append(entry)
+    return dependents
+
+
 def get_dependents(repo_full_name: str, repo_is_empty: bool = False, max_retries: int = 3) -> list[dict] | None:
     """Get dependents (repositories that depend on this repo) by scraping the network/dependents page.
 
@@ -250,38 +281,7 @@ def get_dependents(repo_full_name: str, repo_is_empty: bool = False, max_retries
                 print(f"Warning: Could not find #dependents container for {repo_full_name} - page structure may have changed")
                 return None  # Page structure changed, don't wipe state
 
-            dependents = []
-            # Find all dependent repository entries
-            for item in soup.select('.Box-row'):
-                # Look for the repository link
-                repo_link = item.select_one('a[data-hovercard-type="repository"]')
-                if not repo_link:
-                    continue
-
-                dep_full_name = repo_link.get('href', '').lstrip('/')
-                if not dep_full_name or '/' not in dep_full_name:
-                    continue
-
-                # Get repository info via API
-                try:
-                    repo_info = github_request(f"{GITHUB_API}/repos/{dep_full_name}")
-                    dependents.append({
-                        "full_name": dep_full_name,
-                        "url": f"https://github.com/{dep_full_name}",
-                        "stars": repo_info.get("stargazers_count", 0),
-                        "forks": repo_info.get("forks_count", 0),
-                    })
-                except (requests.exceptions.RequestException, KeyError, ValueError) as e:
-                    print(f"Warning: Could not get info for dependent {dep_full_name}: {e}")
-                    # Still add basic info
-                    dependents.append({
-                        "full_name": dep_full_name,
-                        "url": f"https://github.com/{dep_full_name}",
-                        "stars": 0,
-                        "forks": 0,
-                    })
-
-            return dependents  # Success, return results (may be empty if truly no dependents)
+            return _parse_dependents(soup)  # may be empty if truly no dependents
         except requests.exceptions.RequestException as e:
             if attempt < max_retries - 1:
                 wait_time = 2 ** attempt

--- a/scripts/check-stars.py
+++ b/scripts/check-stars.py
@@ -159,6 +159,8 @@ def get_org_repos() -> list[dict]:
             "stargazers_count": r["stargazers_count"],
             "forks_count": r["forks_count"],
             "watchers_count": r.get("subscribers_count", r.get("watchers_count", 0)),
+            # Empty repos (no commits) have no dependency graph page
+            "is_empty": r.get("size", 0) == 0,
         }
         for r in repos
         if not r.get("private", False)
@@ -210,13 +212,20 @@ def get_watchers(repo_full_name: str) -> list[dict] | None:
         return None
 
 
-def get_dependents(repo_full_name: str, max_retries: int = 3) -> list[dict] | None:
+def get_dependents(repo_full_name: str, repo_is_empty: bool = False, max_retries: int = 3) -> list[dict] | None:
     """Get dependents (repositories that depend on this repo) by scraping the network/dependents page.
 
     Returns:
         list[dict]: List of dependent repos if successful
         None: If fetch failed (to distinguish from "no dependents exist")
     """
+    # An empty repo has no dependency graph, so /network/dependents renders the
+    # "This repository is empty" page with no #dependents container. Treat it as
+    # zero dependents rather than a scrape failure (avoids a false "page structure
+    # may have changed" warning on every run).
+    if repo_is_empty:
+        return []
+
     url = f"https://github.com/{repo_full_name}/network/dependents"
     headers = {
         "User-Agent": "Mozilla/5.0 (compatible; NetresearchBot/1.0)",
@@ -404,7 +413,7 @@ def main():
 
         # Dependents (repositories using this repo)
         known_dependents = set(repo_state.get("dependents", []))
-        dependents = get_dependents(repo_name)
+        dependents = get_dependents(repo_name, repo_is_empty=repo.get("is_empty", False))
         if dependents is not None:
             current_dependents = {d["full_name"] for d in dependents}
             if is_suspicious_empty(current_dependents, known_dependents, "dependents", repo_name):

--- a/tests/test_check_stars.py
+++ b/tests/test_check_stars.py
@@ -17,18 +17,19 @@ check_stars = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(check_stars)
 
 
-def test_empty_repo_returns_no_dependents_without_scraping(monkeypatch=None):
+def test_empty_repo_returns_no_dependents_without_scraping():
     """An empty repo must yield [] (zero dependents) and never hit the network."""
     def _fail(*args, **kwargs):
         raise AssertionError("get_dependents scraped an empty repo instead of short-circuiting")
 
-    # Fail loudly if any HTTP call is attempted for an empty repo.
+    # Fail loudly if any HTTP call is attempted for an empty repo, restoring
+    # the real requests.get afterwards so other tests are unaffected.
+    original_get = check_stars.requests.get
     check_stars.requests.get = _fail  # type: ignore[assignment]
     try:
         result = check_stars.get_dependents("netresearch/dind", repo_is_empty=True)
     finally:
-        # Restore is not required across the tiny standalone run, but keep it tidy.
-        pass
+        check_stars.requests.get = original_get  # type: ignore[assignment]
     assert result == [], f"expected [] for empty repo, got {result!r}"
 
 

--- a/tests/test_check_stars.py
+++ b/tests/test_check_stars.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check-stars.py dependents handling.
+
+Runnable standalone (`python tests/test_check_stars.py`) or via pytest.
+"""
+
+import importlib.util
+import os
+from pathlib import Path
+
+# The module reads MATRIX_WEBHOOK_URL at import time; provide a dummy value.
+os.environ.setdefault("MATRIX_WEBHOOK_URL", "https://example.invalid/webhook")
+
+_MODULE_PATH = Path(__file__).resolve().parent.parent / "scripts" / "check-stars.py"
+_spec = importlib.util.spec_from_file_location("check_stars", _MODULE_PATH)
+check_stars = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(check_stars)
+
+
+def test_empty_repo_returns_no_dependents_without_scraping(monkeypatch=None):
+    """An empty repo must yield [] (zero dependents) and never hit the network."""
+    def _fail(*args, **kwargs):
+        raise AssertionError("get_dependents scraped an empty repo instead of short-circuiting")
+
+    # Fail loudly if any HTTP call is attempted for an empty repo.
+    check_stars.requests.get = _fail  # type: ignore[assignment]
+    try:
+        result = check_stars.get_dependents("netresearch/dind", repo_is_empty=True)
+    finally:
+        # Restore is not required across the tiny standalone run, but keep it tidy.
+        pass
+    assert result == [], f"expected [] for empty repo, got {result!r}"
+
+
+if __name__ == "__main__":
+    test_empty_repo_returns_no_dependents_without_scraping()
+    print("OK: empty repo returns [] without scraping")


### PR DESCRIPTION
The dependents scraper logged `Warning: Could not find #dependents container ... page structure may have changed` on every 15-minute run for two repos.

## Root cause

`netresearch/dind` and `netresearch/mqtt-concourse-ws2812b` are **empty** repositories (`size: 0`, GitHub shows "This repository is empty"). An empty repo has no dependency-graph page, so `/network/dependents` renders without the `#dependents` container. The scraper read that as a structure change → returned `None` → logged the warning every run.

The selector itself is **not** broken: repos with a dependency graph still parse correctly (verified against `netresearch/t3x-rte_ckeditor_image`, 14 direct dependent rows).

## Fix

Short-circuit empty repos (detected from the repo `size` field) to `[]` before scraping. The missing-container path still returns `None` + warning for genuinely unexpected markup on **non-empty** repos, so persisted state is never wiped.

## Verification

- Empty repo → `[]`, no HTTP call, no warning (covered by new test).
- Non-empty populated page → parses 14 dependent rows (unchanged).
- Non-empty page missing `#dependents` → still `None` + warning (safety preserved).
- Empty-repo set org-wide is exactly `{dind, mqtt-concourse-ws2812b}` — the fix targets precisely the two warning repos.

Adds `tests/test_check_stars.py` (runnable standalone via `python tests/test_check_stars.py` or under pytest; the repo had no test harness).

Unrelated to the fork/watcher notification path, which was separately verified healthy (state matches live direct forks/subscribers across all 278 repos).