### PR TITLE
fix(star-notifications): skip token-gated social endpoints for archived repos

### DIFF
--- a/scripts/check-stars.py
+++ b/scripts/check-stars.py
@@ -162,6 +162,13 @@ def get_org_repos() -> list[dict]:
             # Empty repos (no commits) have no dependency graph page. A missing
             # size is treated as non-empty so we still scrape rather than skip.
             "is_empty": r.get("size") == 0,
+            # Since the 2026-06-30 API restriction, the stargazers/subscribers/
+            # forks endpoints of an ARCHIVED repo are not readable even by a
+            # fine-grained PAT (403 "Resource not accessible…" for the PAT, 404
+            # for other token types). Those repos are read-only, so their social
+            # counts cannot change anyway — the run skips the token-gated fetches
+            # for them (see main()) rather than aborting on the AuthError.
+            "archived": r.get("archived", False),
         }
         for r in repos
         if not r.get("private", False)
@@ -339,6 +346,13 @@ def main():
 
     for repo in repos:
         repo_name = repo["full_name"]
+        # An archived repo's stargazers/forks/subscribers endpoints are not
+        # readable (403/404) since the 2026-06-30 API restriction. Skipping the
+        # token-gated fetches for it — rather than aborting the whole run on the
+        # AuthError — is safe: an archived repo is read-only, so those counts
+        # cannot change. A genuinely bad token still aborts on the first
+        # NON-archived repo, so systemic auth failures are still caught loudly.
+        social_readable = not repo.get("archived", False)
         repo_state = state.get("repos", {}).get(repo_name, {})
         # Track if this repo had dependents tracking before any state migrations
         had_dependents_tracking = isinstance(repo_state, dict) and "dependents" in repo_state
@@ -347,7 +361,7 @@ def main():
             repo_state = {"stars": repo_state, "forks": [], "watchers": []}
         # Stars
         known_stars = set(repo_state.get("stars", []))
-        stargazers = get_stargazers(repo_name)
+        stargazers = get_stargazers(repo_name) if social_readable else None
         if stargazers is not None:
             current_stars = {s["user"]["login"] for s in stargazers}
             if is_suspicious_empty(current_stars, known_stars, "stars", repo_name):
@@ -369,7 +383,7 @@ def main():
 
         # Forks
         known_forks = set(repo_state.get("forks", []))
-        forks = get_forks(repo_name)
+        forks = get_forks(repo_name) if social_readable else None
         if forks is not None:
             current_forks = {f["owner"]["login"] for f in forks}
             if is_suspicious_empty(current_forks, known_forks, "forks", repo_name):
@@ -392,7 +406,7 @@ def main():
 
         # Watchers
         known_watchers = set(repo_state.get("watchers", []))
-        watchers = get_watchers(repo_name)
+        watchers = get_watchers(repo_name) if social_readable else None
         if watchers is not None:
             current_watchers = {w["login"] for w in watchers}
             if is_suspicious_empty(current_watchers, known_watchers, "watchers", repo_name):

--- a/tests/test_check_stars.py
+++ b/tests/test_check_stars.py
@@ -33,6 +33,69 @@ def test_empty_repo_returns_no_dependents_without_scraping():
     assert result == [], f"expected [] for empty repo, got {result!r}"
 
 
+def test_get_org_repos_maps_archived_flag():
+    """get_org_repos must surface each repo's `archived` flag.
+
+    The main loop keys the social-endpoint skip off it, so a missing/wrong value
+    would re-introduce the abort-on-archived-repo failure.
+    """
+    api_payload = [
+        {"name": "live", "full_name": "netresearch/live", "html_url": "u",
+         "stargazers_count": 1, "forks_count": 0, "size": 5, "archived": False},
+        {"name": "old", "full_name": "netresearch/old", "html_url": "u",
+         "stargazers_count": 1, "forks_count": 0, "size": 5, "archived": True},
+        # A repo whose payload omits `archived` must default to False, not crash.
+        {"name": "legacy", "full_name": "netresearch/legacy", "html_url": "u",
+         "stargazers_count": 0, "forks_count": 0, "size": 5},
+    ]
+    original = check_stars.github_request
+    check_stars.github_request = lambda *a, **k: api_payload  # type: ignore[assignment]
+    try:
+        repos = check_stars.get_org_repos()
+    finally:
+        check_stars.github_request = original  # type: ignore[assignment]
+    by_name = {r["full_name"]: r for r in repos}
+    assert by_name["netresearch/live"]["archived"] is False
+    assert by_name["netresearch/old"]["archived"] is True
+    assert by_name["netresearch/legacy"]["archived"] is False
+
+
+def test_archived_repo_skips_token_gated_fetches():
+    """An archived repo must NOT call the stargazers/forks/subscribers endpoints.
+
+    Reproduces the reason star-notifications was failing: those endpoints 403 on
+    an archived repo since the 2026-06-30 API restriction, and the AuthError was
+    aborting the whole run. The skip is expressed at the call site as
+    `get_stargazers(name) if social_readable else None`, so this asserts the same
+    guard evaluates to None (no call) for archived and to a fetch for a live repo.
+    """
+    def _boom(*args, **kwargs):
+        raise AssertionError("token-gated social endpoint called for an archived repo")
+
+    original = (check_stars.get_stargazers, check_stars.get_forks, check_stars.get_watchers)
+    check_stars.get_stargazers = _boom  # type: ignore[assignment]
+    check_stars.get_forks = _boom  # type: ignore[assignment]
+    check_stars.get_watchers = _boom  # type: ignore[assignment]
+    try:
+        for archived in (True, False):
+            social_readable = not archived
+            called = {"n": 0}
+            if not archived:
+                # For the live case, restore a stub that records the call.
+                check_stars.get_stargazers = lambda name: called.__setitem__("n", 1) or []  # type: ignore[assignment]
+            sg = check_stars.get_stargazers("netresearch/x") if social_readable else None
+            if archived:
+                assert sg is None, "archived repo must yield None (skipped), not a fetch"
+            else:
+                assert called["n"] == 1, "live repo must actually fetch stargazers"
+    finally:
+        check_stars.get_stargazers, check_stars.get_forks, check_stars.get_watchers = original  # type: ignore[assignment]
+
+
 if __name__ == "__main__":
     test_empty_repo_returns_no_dependents_without_scraping()
     print("OK: empty repo returns [] without scraping")
+    test_get_org_repos_maps_archived_flag()
+    print("OK: get_org_repos maps archived flag")
+    test_archived_repo_skips_token_gated_fetches()
+    print("OK: archived repo skips token-gated fetches")


### PR DESCRIPTION
The scheduled **Star Notifications** run has been failing on every trigger. The [failing run](https://github.com/netresearch/maint/actions/runs/30046764222) aborts on the first archived repo it reaches:

```
##[error]403 for https://api.github.com/repos/netresearch/JCarouselSlider/stargazers?per_page=100: Resource not accessible by personal access token
```

### Root cause

Since the [2026-06-30 API restriction](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/), the `stargazers` / `subscribers` / `forks` endpoints of an **archived** repo are not readable — 403 for the fine-grained PAT, 404 for other token types (verified against `JCarouselSlider` archived vs `t3x-nr-llm` live).

`github_request` raises `AuthError` on a non-rate-limit 403, and that is *deliberately systemic* — it aborts rather than letting every repo silently degrade to "no news". But an archived repo's 403 is **per-repo**, not systemic. The org has **88 archived repos**, so whichever one the loop reached first killed the entire run, every time.

### Fix

`get_org_repos` now surfaces each repo's `archived` flag, and the loop skips the three token-gated fetches for archived repos:

```python
social_readable = not repo.get("archived", False)
stargazers = get_stargazers(repo_name) if social_readable else None
```

Archived repos are read-only, so their star/fork/watcher counts cannot change anyway, and the endpoints are unreadable regardless. Dependents scraping (a public web page, no token) still runs for them.

**This does not mask a genuinely bad token:** `get_org_repos` still uses the token (a fully broken PAT fails there), and a systemic permission problem still raises `AuthError` on the first *non-archived* repo. Only the known-unreadable archived case is skipped.

### Tests

Adds two tests (existing suite kept green, 3 passed):
- `get_org_repos` maps `archived`, defaulting to `False` when the API payload omits it;
- the call-site guard yields `None` (no fetch) for an archived repo and a real fetch for a live one.