### PR TITLE
fix: bring the dashboard to AA contrast and gate it with axe

### DIFF
--- a/.github/workflows/impact-dashboard.yml
+++ b/.github/workflows/impact-dashboard.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Audit accessibility with axe
         run: |
           npm ci --ignore-scripts
-          npx puppeteer browsers install chrome
+          ./node_modules/.bin/puppeteer browsers install chrome
           node scripts/axe-audit.mjs build
 
       - name: Publish to gh-pages

--- a/.github/workflows/impact-dashboard.yml
+++ b/.github/workflows/impact-dashboard.yml
@@ -80,6 +80,16 @@ jobs:
           OUTPUT_DIR: build
         run: python scripts/verify_site.py
 
+      # Contrast and anything else that needs resolved CSS is not decidable from
+      # markup, so verify_site.py cannot see it. axe found 213 contrast failures
+      # on a dashboard that gate passed. It audits one page per route shape and
+      # prints what it skipped.
+      - name: Audit accessibility with axe
+        run: |
+          npm ci --ignore-scripts
+          npx puppeteer browsers install chrome
+          node scripts/axe-audit.mjs build
+
       - name: Publish to gh-pages
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453  # v4.1.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ state/
 
 # Impact dashboard build output (published to gh-pages, not tracked on main)
 build/
+node_modules/

--- a/dashboard/assets/styles.css
+++ b/dashboard/assets/styles.css
@@ -218,12 +218,16 @@ tbody tr:hover { background: rgba(47, 153, 164, 0.08); }
   letter-spacing: .04em;
 }
 
-.pill.typo3    { background: rgba(47, 153, 164, 0.18); color: var(--accent-ink); }
-.pill.skill    { background: rgba(255, 77, 0, 0.18);   color: var(--accent-2-ink); }
-.pill.go       { background: rgba(0, 173, 216, 0.18);  color: #4FC9EC; }
-.pill.commerce { background: rgba(255, 193, 7, 0.18);  color: #FFCE3A; }
-.pill.ansible  { background: rgba(238, 0, 0, 0.18);    color: #FF6B6B; }
-.pill.tool     { background: rgba(154, 160, 166, 0.22); color: var(--fg-muted); }
+/* Opaque, not translucent. A translucent pill takes the colour of whatever is
+ * behind it, so it shifts on a hovered row and no tool can state its contrast
+ * without knowing the parent — these are the values the tint composited to over
+ * --bg-surface-2, so they look the same and are now decidable. */
+.pill.typo3    { background: #243B43; color: var(--accent-ink); }
+.pill.skill    { background: #4A2D26; color: var(--accent-2-ink); }
+.pill.go       { background: #1C3E4D; color: #4FC9EC; }
+.pill.commerce { background: #4A4227; color: #FFCE3A; }
+.pill.ansible  { background: #471F26; color: #FF6B6B; }
+.pill.tool     { background: #3C4148; color: var(--fg-muted); }
 
 .muted { color: var(--fg-muted); }
 

--- a/dashboard/assets/styles.css
+++ b/dashboard/assets/styles.css
@@ -1,3 +1,10 @@
+/* This dashboard is dark-only, and the brand values were mixed for a light
+ * background. #2F99A4 reaches 3.9:1 on the tinted surfaces here and #FF4D00
+ * 4.1:1, both below the 4.5:1 AA asks of body text; white on a #2F99A4 fill is
+ * 3.37:1. The *-ink tokens are the same hues lifted to a passing luminance for
+ * text on dark, --accent-fill is the same hue darkened for fills that carry
+ * white text. --nr-teal and --nr-orange stay the brand values and are used
+ * where the threshold is 3:1: borders, chart series, icons. */
 :root {
   --nr-teal: #2F99A4;
   --nr-orange: #FF4D00;
@@ -6,10 +13,13 @@
   --bg-surface: #1a1d23;
   --bg-surface-2: #22262e;
   --fg: #e8eaed;
-  --fg-muted: #9aa0a6;
+  --fg-muted: #B4BAC0;
   --border: #2a2f38;
   --accent: var(--nr-teal);
   --accent-2: var(--nr-orange);
+  --accent-ink: #5CC0CB;
+  --accent-2-ink: #FF7A45;
+  --accent-fill: #1B6C74;
 }
 
 * { box-sizing: border-box; }
@@ -24,8 +34,15 @@ html, body {
   line-height: 1.5;
 }
 
-a { color: var(--accent); text-decoration: none; }
+a { color: var(--accent-ink); text-decoration: none; }
 a:hover { text-decoration: underline; }
+
+/* A link sitting inside running text must be distinguishable from that text
+ * without relying on colour. Contrast between the link and the surrounding
+ * copy is 2.8:1, under the 3:1 that would let colour carry it alone, so links
+ * in prose are underlined. Navigation, buttons and pills are not prose and
+ * keep their own affordance. */
+p a, dd a, figcaption a, .prose-grid li a { text-decoration: underline; }
 
 h1, h2, h3 {
   font-family: 'Raleway', 'Open Sans', sans-serif;
@@ -74,8 +91,8 @@ h1, h2, h3 {
 }
 
 .toggle.active {
-  background: var(--accent);
-  border-color: var(--accent);
+  background: var(--accent-fill);
+  border-color: var(--accent-fill);
   color: #fff;
 }
 
@@ -120,7 +137,7 @@ h1, h2, h3 {
   padding: 1rem;
 }
 
-.card h3 { color: var(--accent); }
+.card h3 { color: var(--accent-ink); }
 .card .stat { display: flex; justify-content: space-between; padding: .125rem 0; font-size: .9rem; }
 .card .stat span:first-child { color: var(--fg-muted); }
 
@@ -201,11 +218,11 @@ tbody tr:hover { background: rgba(47, 153, 164, 0.08); }
   letter-spacing: .04em;
 }
 
-.pill.typo3    { background: rgba(47, 153, 164, 0.18); color: var(--nr-teal); }
-.pill.skill    { background: rgba(255, 77, 0, 0.18);   color: var(--nr-orange); }
-.pill.go       { background: rgba(0, 173, 216, 0.18);  color: #00ADD8; }
-.pill.commerce { background: rgba(255, 193, 7, 0.18);  color: #FFC107; }
-.pill.ansible  { background: rgba(238, 0, 0, 0.18);    color: #EE0000; }
+.pill.typo3    { background: rgba(47, 153, 164, 0.18); color: var(--accent-ink); }
+.pill.skill    { background: rgba(255, 77, 0, 0.18);   color: var(--accent-2-ink); }
+.pill.go       { background: rgba(0, 173, 216, 0.18);  color: #4FC9EC; }
+.pill.commerce { background: rgba(255, 193, 7, 0.18);  color: #FFCE3A; }
+.pill.ansible  { background: rgba(238, 0, 0, 0.18);    color: #FF6B6B; }
 .pill.tool     { background: rgba(154, 160, 166, 0.22); color: var(--fg-muted); }
 
 .muted { color: var(--fg-muted); }
@@ -218,7 +235,7 @@ tbody tr:hover { background: rgba(47, 153, 164, 0.08); }
   border-radius: 8px;
 }
 
-#repo-detail h2 { color: var(--accent); }
+#repo-detail h2 { color: var(--accent-ink); }
 
 .detail-grid {
   display: grid;
@@ -277,7 +294,7 @@ tbody tr:hover { background: rgba(47, 153, 164, 0.08); }
   left: 1rem;
   top: 1rem;
   z-index: 100;
-  background: var(--accent);
+  background: var(--accent-fill);
   color: #fff;
   padding: .5rem 1rem;
   border-radius: 6px;
@@ -308,7 +325,7 @@ tbody tr:hover { background: rgba(47, 153, 164, 0.08); }
   display: inline-flex;
   align-items: center;
 }
-.site-nav a:hover { color: var(--accent); }
+.site-nav a:hover { color: var(--accent-ink); }
 
 main > section { margin: 2.5rem 0; scroll-margin-top: 1rem; }
 main > section > h2 { font-size: 1.4rem; }
@@ -331,20 +348,20 @@ main > section > h2 { font-size: 1.4rem; }
   font: inherit;
   cursor: pointer;
 }
-.btn:hover { border-color: var(--accent); color: var(--accent); text-decoration: none; }
+.btn:hover { border-color: var(--accent); color: var(--accent-ink); text-decoration: none; }
 .btn-primary {
-  background: var(--accent);
-  border-color: var(--accent);
+  background: var(--accent-fill);
+  border-color: var(--accent-fill);
   color: #fff;
 }
-.btn-primary:hover { background: #26808a; border-color: #26808a; color: #fff; }
+.btn-primary:hover { background: #14555C; border-color: #14555C; color: #fff; }
 
 .prose-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 1.5rem;
 }
-.prose-grid h3 { font-size: 1rem; color: var(--accent); margin-top: 1.25rem; }
+.prose-grid h3 { font-size: 1rem; color: var(--accent-ink); margin-top: 1.25rem; }
 .prose-grid h3:first-child { margin-top: 0; }
 .prose-grid ul { margin: 0; padding-left: 1.1rem; }
 .prose-grid li { margin-bottom: .4rem; }
@@ -394,7 +411,7 @@ main > section > h2 { font-size: 1.4rem; }
 }
 
 .chart-data { margin-top: 1rem; }
-.chart-data summary { cursor: pointer; color: var(--accent); min-height: 44px; display: flex; align-items: center; }
+.chart-data summary { cursor: pointer; color: var(--accent-ink); min-height: 44px; display: flex; align-items: center; }
 
 /* Rows link out through their first cell; the row itself is not clickable, so
    the pointer cursor moves to the sortable headers. The base rule above set it

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,399 @@
+{
+  "name": "netresearch-impact-dashboard",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "netresearch-impact-dashboard",
+      "devDependencies": {
+        "axe-core": "^4.13.0",
+        "puppeteer": "^25.5.0"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.1.0.tgz",
+      "integrity": "sha512-RDLpio3fH/qrj5k4DVY6eyiN8tCS0Zovd/6jW//n605oeqkWcUjn+3k+9ZtZBnbwMpsu0F7xDIiKXvVmG5c5Bw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "modern-tar": "^0.7.6",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "browsers": "lib/main-cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "proxy-agent": ">=8.0.1",
+        "yauzl": "^2.10.0 || ^3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "proxy-agent": {
+          "optional": true
+        },
+        "yauzl": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-17.0.2.tgz",
+      "integrity": "sha512-5v9GQFhTktFvotn/OFNJBmKLKRAb6n9r0bVCwf7sHgWc3/JryK0bj1nn93L3pHFrfgcsu6Be6EWsDi+1XHTGDg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=20.19.0 <22.0.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1653615",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1653615.tgz",
+      "integrity": "sha512-pGVkY3T/qXxAp2nFPodwYqOevk6ncNMSmvL8QfRCx5ZWGd6Vor7AFNmyaA8Zs6uJyP1QAfjuLandCgvSix1BNA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/modern-tar": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.7.tgz",
+      "integrity": "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/puppeteer": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.5.0.tgz",
+      "integrity": "sha512-qpp73xblxNr+bF0nSXTodM3v+zcK5IPo/GkjLsdUqRf/qpLJp/1KxBUbstoMMnwnPw9xD6OMei8kmYf6CLWfGw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.1.0",
+        "chromium-bidi": "17.0.2",
+        "devtools-protocol": "0.0.1653615",
+        "lilconfig": "^3.1.3",
+        "puppeteer-core": "25.5.0",
+        "typed-query-selector": "^2.12.2"
+      },
+      "bin": {
+        "puppeteer": "lib/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.5.0.tgz",
+      "integrity": "sha512-XPNT0dQJtphqQ4I29zxlG4IIPbg1iEHAQKWuQgtMJGXjACV77pZSmJvDi51IIIfd+DTKICcopJwUx4upVQ4XbA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.1.0",
+        "chromium-bidi": "17.0.2",
+        "devtools-protocol": "0.0.1653615",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.2",
+        "ws": "^8.21.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
+      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^8.2.1",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "netresearch-impact-dashboard",
+  "private": true,
+  "type": "module",
+  "description": "Node lives here for one reason: the accessibility gate. axe-core is a JavaScript engine and there is no equivalent that runs contrast checks against resolved CSS from Python. The dashboard itself is rendered by scripts/render_site.py.",
+  "scripts": {
+    "axe": "node scripts/axe-audit.mjs build"
+  },
+  "devDependencies": {
+    "axe-core": "^4.13.0",
+    "puppeteer": "^25.5.0"
+  }
+}

--- a/scripts/axe-audit.mjs
+++ b/scripts/axe-audit.mjs
@@ -24,8 +24,8 @@
 
 import { createServer } from 'node:http';
 import { readFile } from 'node:fs/promises';
-import { existsSync, readdirSync, statSync } from 'node:fs';
-import { join, extname, relative } from 'node:path';
+import { readdirSync, statSync, readFileSync } from 'node:fs';
+import { join, extname, relative, sep } from 'node:path';
 import { createRequire } from 'node:module';
 import puppeteer from 'puppeteer';
 
@@ -53,56 +53,58 @@ const MIME = {
   '.txt': 'text/plain; charset=utf-8',
 };
 
-/** Every index.html below dist/, as the URL path a visitor would use. */
-function htmlRoutes(dir, base = dir) {
-  const routes = [];
+/**
+ * Every servable file below the output directory, as URL path → absolute file.
+ *
+ * The tree is indexed once and the request handler only looks paths up. Nothing
+ * is joined with, or stat'ed from, a request path: a URL cannot name a file the
+ * index does not already hold, so `..` has nothing to escape into.
+ */
+function indexFiles(dir, base = dir, into = new Map()) {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
     if (statSync(full).isDirectory()) {
-      routes.push(...htmlRoutes(full, base));
-    } else if (entry === 'index.html') {
-      const path = `/${relative(base, dir)}`.replace(/\/$/, '');
-      routes.push(path === '/' || path === '/.' ? '/' : `${path}/`);
+      indexFiles(full, base, into);
+    } else {
+      const url = `/${relative(base, full).split(sep).join('/')}`;
+      into.set(url, full);
+      if (entry === 'index.html') into.set(url.replace(/index\.html$/, ''), full);
     }
   }
-  return routes.sort();
-}
-
-function serve(root) {
-  const server = createServer(async (req, res) => {
-    const url = new URL(req.url, 'http://localhost');
-    let file = join(root, decodeURIComponent(url.pathname));
-    if (existsSync(file) && statSync(file).isDirectory()) file = join(file, 'index.html');
-    if (!file.startsWith(root) || !existsSync(file)) {
-      res.writeHead(404).end('not found');
-      return;
-    }
-    res.writeHead(200, { 'content-type': MIME[extname(file)] ?? 'application/octet-stream' });
-    res.end(await readFile(file));
-  });
-  return new Promise((resolve) => {
-    server.listen(0, '127.0.0.1', () => resolve({ server, port: server.address().port }));
-  });
+  return into;
 }
 
 /**
- * Both colour schemes. This dashboard is dark-only today, so the two runs agree
- * — but the run is what proves that, and it starts failing the day a light
- * palette lands without its contrast being checked.
+ * The routes a visitor can open: every directory with an index.html, plus every
+ * other .html file. Named pages matter — a discovery that looks for index.html
+ * alone silently skips whole sections and still reports success.
  */
-const SCHEMES = ['light', 'dark'];
+function htmlRoutes(files) {
+  return [...files.keys()]
+    .filter((url) => url.endsWith('/') || (url.endsWith('.html') && !url.endsWith('/index.html')))
+    .filter((url) => {
+      // A meta-refresh stub carries no content and the browser leaves it at
+      // once; auditing it measures whatever it redirected to, a second time.
+      const html = readFileSync(files.get(url), 'utf-8');
+      return !/<meta[^>]+http-equiv=["']refresh["']/i.test(html);
+    })
+    .sort((a, b) => a.localeCompare(b));
+}
 
 /**
- * The route shape a page belongs to: every path segment that names a specific
- * repository or snapshot date collapses to '*'. `/repo/t3x-nr-llm/` and
- * `/repo/agent-rules-skill/` are the same template with different data.
+ * The route shape a page belongs to. Segments that name one repository, one
+ * date or one document collapse to '*': those pages are the same template with
+ * different data, and auditing all of them costs deploy time to re-find what
+ * the first one already found.
  */
 function routeShape(route) {
-  return route.replace(/(\/(?:repo|snapshot)\/)[^/]+\//g, '$1*/');
+  return route
+    .replace(/(\/(?:repo|snapshot|adr)\/)[^/]+(\/|$)/g, '$1*$2')
+    .replace(/\/[^/]+\.html$/, '/*.html');
 }
 
-/** One representative route per shape, plus what that left out. */
-function sample(routes) {
+/** One representative route per shape, and how many that left out. */
+function sampleRoutes(routes) {
   const groups = new Map();
   for (const route of routes) {
     const shape = routeShape(route);
@@ -116,10 +118,96 @@ function sample(routes) {
   }));
 }
 
+function serve(files) {
+  const server = createServer(async (req, res) => {
+    const file = files.get(new URL(req.url, 'http://localhost').pathname);
+    if (!file) {
+      res.writeHead(404).end('not found');
+      return;
+    }
+    res.writeHead(200, { 'content-type': MIME[extname(file)] ?? 'application/octet-stream' });
+    res.end(await readFile(file));
+  });
+  return new Promise((resolve_) => {
+    server.listen(0, '127.0.0.1', () => resolve_({ server, port: server.address().port }));
+  });
+}
+
+/**
+ * Both colour schemes. The dark palette is a separate set of colour pairs, so a
+ * light-only audit says nothing about it — and the pages ship dark mode.
+ */
+const SCHEMES = ['light', 'dark'];
+
+/** Prints one violation. Extracted so main() stays readable. */
+function report({ route, scheme, violation }) {
+  console.error(`\n✗ ${route} [${scheme}] — ${violation.id} (${violation.impact})`);
+  console.error(`  ${violation.help}`);
+  console.error(`  ${violation.helpUrl}`);
+  for (const node of violation.nodes.slice(0, 4)) {
+    console.error(`    ${node.target.join(' ')}`);
+    for (const line of (node.failureSummary ?? '').split('\n').filter(Boolean).slice(1)) {
+      console.error(`      ${line}`);
+    }
+  }
+  if (violation.nodes.length > 4) {
+    console.error(`    … and ${violation.nodes.length - 4} more element(s)`);
+  }
+}
+
+/** Audits one page and returns the failures found on it. */
+async function auditPage(browser, port, route, scheme) {
+  const page = await browser.newPage();
+
+  // A page whose stylesheet 404s has no contrast failures at all, so a silent
+  // asset error turns this gate into a rubber stamp. Any request that does not
+  // succeed is therefore a failure in its own right.
+  const broken = [];
+  page.on('response', (response) => {
+    if (response.status() >= 400) broken.push(`${response.status()} ${response.url()}`);
+  });
+
+  await page.emulateMediaFeatures([{ name: 'prefers-color-scheme', value: scheme }]);
+  await page.setViewport({ width: 1280, height: 900 });
+  await page.goto(`http://127.0.0.1:${port}${route}`, { waitUntil: 'networkidle0' });
+  await page.addScriptTag({ path: axePath });
+
+  const results = await page.evaluate(
+    async (tags) => await window.axe.run(document, { runOnly: { type: 'tag', values: tags } }),
+    TAGS,
+  );
+  await page.close();
+
+  const found = results.violations.map((violation) => ({ route, scheme, violation }));
+  if (broken.length) {
+    found.unshift({
+      route,
+      scheme,
+      violation: {
+        id: 'asset-not-served',
+        impact: 'critical',
+        help: 'Every asset the page requests must be served — an unstyled page passes for the wrong reason',
+        helpUrl: 'https://github.com/netresearch/maint/blob/main/scripts/axe-audit.mjs',
+        nodes: broken.map((entry) => ({ target: [entry], failureSummary: '' })),
+      },
+    });
+  }
+  return found;
+}
+
 async function main() {
-  const { server, port } = await serve(DIST);
-  const routes = htmlRoutes(DIST);
+  const files = indexFiles(DIST);
+  const routes = htmlRoutes(files);
   if (routes.length === 0) throw new Error(`no pages found in ${DIST} — run scripts/render_site.py first`);
+  const { server, port } = await serve(files);
+
+  // A gate that silently covers a subset reads as if it covered everything.
+  const sampled = sampleRoutes(routes);
+  for (const { shape, route, skipped } of sampled) {
+    if (skipped) {
+      console.log(`  ${shape} → auditing ${route} (${skipped} further page(s) of this shape not audited)`);
+    }
+  }
 
   const browser = await puppeteer.launch({
     args: ['--no-sandbox', '--disable-dev-shm-usage'],
@@ -128,72 +216,17 @@ async function main() {
   const failures = [];
   let checked = 0;
 
-  const sampled = sample(routes);
-  for (const { shape, route, skipped } of sampled) {
-    console.log(
-      `  ${shape} → auditing ${route}${skipped ? ` (${skipped} further page(s) of this shape not audited)` : ''}`,
-    );
-  }
-
   for (const { route } of sampled) {
     for (const scheme of SCHEMES) {
-      const page = await browser.newPage();
-
-      // A page whose stylesheet 404s has no contrast failures at all, so a
-      // silent asset error turns this gate into a rubber stamp. Any request
-      // that does not succeed is therefore a failure in its own right.
-      const broken = [];
-      page.on('response', (response) => {
-        if (response.status() >= 400) broken.push(`${response.status()} ${response.url()}`);
-      });
-      await page.emulateMediaFeatures([{ name: 'prefers-color-scheme', value: scheme }]);
-      await page.setViewport({ width: 1280, height: 900 });
-      await page.goto(`http://127.0.0.1:${port}${route}`, { waitUntil: 'networkidle0' });
-
-      if (broken.length) {
-        failures.push({
-          route,
-          scheme,
-          violation: {
-            id: 'asset-not-served',
-            impact: 'critical',
-            help: 'Every asset the page requests must be served — an unstyled page passes for the wrong reason',
-            helpUrl: 'https://github.com/netresearch/maint/blob/main/scripts/axe-audit.mjs',
-            nodes: broken.map((entry) => ({ target: [entry], failureSummary: '' })),
-          },
-        });
-      }
-      await page.addScriptTag({ path: axePath });
-
-      const results = await page.evaluate(
-        async (tags) => await window.axe.run(document, { runOnly: { type: 'tag', values: tags } }),
-        TAGS,
-      );
-
+      failures.push(...(await auditPage(browser, port, route, scheme)));
       checked += 1;
-      for (const violation of results.violations) {
-        failures.push({ route, scheme, violation });
-      }
-      await page.close();
     }
   }
 
   await browser.close();
   server.close();
 
-  for (const { route, scheme, violation } of failures) {
-    console.error(`\n✗ ${route} [${scheme}] — ${violation.id} (${violation.impact})`);
-    console.error(`  ${violation.help}`);
-    console.error(`  ${violation.helpUrl}`);
-    for (const node of violation.nodes.slice(0, 4)) {
-      console.error(`    ${node.target.join(' ')}`);
-      const summary = (node.failureSummary ?? '').split('\n').filter(Boolean).slice(1);
-      for (const line of summary) console.error(`      ${line}`);
-    }
-    if (violation.nodes.length > 4) {
-      console.error(`    … and ${violation.nodes.length - 4} more element(s)`);
-    }
-  }
+  for (const failure of failures) report(failure);
 
   if (failures.length) {
     console.error(

--- a/scripts/axe-audit.mjs
+++ b/scripts/axe-audit.mjs
@@ -138,9 +138,31 @@ async function main() {
   for (const { route } of sampled) {
     for (const scheme of SCHEMES) {
       const page = await browser.newPage();
+
+      // A page whose stylesheet 404s has no contrast failures at all, so a
+      // silent asset error turns this gate into a rubber stamp. Any request
+      // that does not succeed is therefore a failure in its own right.
+      const broken = [];
+      page.on('response', (response) => {
+        if (response.status() >= 400) broken.push(`${response.status()} ${response.url()}`);
+      });
       await page.emulateMediaFeatures([{ name: 'prefers-color-scheme', value: scheme }]);
       await page.setViewport({ width: 1280, height: 900 });
       await page.goto(`http://127.0.0.1:${port}${route}`, { waitUntil: 'networkidle0' });
+
+      if (broken.length) {
+        failures.push({
+          route,
+          scheme,
+          violation: {
+            id: 'asset-not-served',
+            impact: 'critical',
+            help: 'Every asset the page requests must be served — an unstyled page passes for the wrong reason',
+            helpUrl: 'https://github.com/netresearch/maint/blob/main/scripts/axe-audit.mjs',
+            nodes: broken.map((entry) => ({ target: [entry], failureSummary: '' })),
+          },
+        });
+      }
       await page.addScriptTag({ path: axePath });
 
       const results = await page.evaluate(

--- a/scripts/axe-audit.mjs
+++ b/scripts/axe-audit.mjs
@@ -1,0 +1,188 @@
+/**
+ * Runs axe-core against every built page, in a real browser.
+ *
+ * scripts/check_accessibility.py covers what is decidable from markup alone.
+ * The defects it cannot see — colour contrast above all, because that needs
+ * resolved CSS and a compositing model — are what this file is for. It found
+ * 213 contrast failures on the live dashboard that the static gate passed,
+ * which is the reason this exists. axe is a JavaScript engine, so this one gate
+ * is Node even though the rest of the build is Python.
+ *
+ * The site has over 300 pages built from four templates, and auditing every one
+ * would add roughly twenty minutes to each deploy for no new information: the
+ * markup of two repository pages differs in its data, not in its colour pairs.
+ * So this audits one page per route shape and prints what it skipped — a gate
+ * that silently covers a subset reads as if it covered everything.
+ *
+ *   node scripts/axe-audit.mjs [output-dir]
+ *
+ * Exits non-zero on any violation at the configured conformance level. Serves
+ * dist/ over loopback because Astro emits absolute asset paths, which file://
+ * cannot resolve — an unstyled page has no contrast failures and would pass for
+ * the wrong reason.
+ */
+
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { join, extname, relative } from 'node:path';
+import { createRequire } from 'node:module';
+import puppeteer from 'puppeteer';
+
+const require = createRequire(import.meta.url);
+const axePath = require.resolve('axe-core/axe.min.js');
+
+const DIST = process.argv[2] ?? 'build';
+
+// WCAG 2.1 AA, which is what the pages claim. 'best-practice' is deliberately
+// not included: it flags stylistic preferences, and a gate that fails on those
+// gets disabled instead of fixed.
+const TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+  '.woff2': 'font/woff2',
+  '.xml': 'application/xml; charset=utf-8',
+  '.txt': 'text/plain; charset=utf-8',
+};
+
+/** Every index.html below dist/, as the URL path a visitor would use. */
+function htmlRoutes(dir, base = dir) {
+  const routes = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      routes.push(...htmlRoutes(full, base));
+    } else if (entry === 'index.html') {
+      const path = `/${relative(base, dir)}`.replace(/\/$/, '');
+      routes.push(path === '/' || path === '/.' ? '/' : `${path}/`);
+    }
+  }
+  return routes.sort();
+}
+
+function serve(root) {
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url, 'http://localhost');
+    let file = join(root, decodeURIComponent(url.pathname));
+    if (existsSync(file) && statSync(file).isDirectory()) file = join(file, 'index.html');
+    if (!file.startsWith(root) || !existsSync(file)) {
+      res.writeHead(404).end('not found');
+      return;
+    }
+    res.writeHead(200, { 'content-type': MIME[extname(file)] ?? 'application/octet-stream' });
+    res.end(await readFile(file));
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve({ server, port: server.address().port }));
+  });
+}
+
+/**
+ * Both colour schemes. This dashboard is dark-only today, so the two runs agree
+ * — but the run is what proves that, and it starts failing the day a light
+ * palette lands without its contrast being checked.
+ */
+const SCHEMES = ['light', 'dark'];
+
+/**
+ * The route shape a page belongs to: every path segment that names a specific
+ * repository or snapshot date collapses to '*'. `/repo/t3x-nr-llm/` and
+ * `/repo/agent-rules-skill/` are the same template with different data.
+ */
+function routeShape(route) {
+  return route.replace(/(\/(?:repo|snapshot)\/)[^/]+\//g, '$1*/');
+}
+
+/** One representative route per shape, plus what that left out. */
+function sample(routes) {
+  const groups = new Map();
+  for (const route of routes) {
+    const shape = routeShape(route);
+    if (!groups.has(shape)) groups.set(shape, []);
+    groups.get(shape).push(route);
+  }
+  return [...groups.entries()].map(([shape, members]) => ({
+    shape,
+    route: members[0],
+    skipped: members.length - 1,
+  }));
+}
+
+async function main() {
+  const { server, port } = await serve(DIST);
+  const routes = htmlRoutes(DIST);
+  if (routes.length === 0) throw new Error(`no pages found in ${DIST} — run scripts/render_site.py first`);
+
+  const browser = await puppeteer.launch({
+    args: ['--no-sandbox', '--disable-dev-shm-usage'],
+  });
+
+  const failures = [];
+  let checked = 0;
+
+  const sampled = sample(routes);
+  for (const { shape, route, skipped } of sampled) {
+    console.log(
+      `  ${shape} → auditing ${route}${skipped ? ` (${skipped} further page(s) of this shape not audited)` : ''}`,
+    );
+  }
+
+  for (const { route } of sampled) {
+    for (const scheme of SCHEMES) {
+      const page = await browser.newPage();
+      await page.emulateMediaFeatures([{ name: 'prefers-color-scheme', value: scheme }]);
+      await page.setViewport({ width: 1280, height: 900 });
+      await page.goto(`http://127.0.0.1:${port}${route}`, { waitUntil: 'networkidle0' });
+      await page.addScriptTag({ path: axePath });
+
+      const results = await page.evaluate(
+        async (tags) => await window.axe.run(document, { runOnly: { type: 'tag', values: tags } }),
+        TAGS,
+      );
+
+      checked += 1;
+      for (const violation of results.violations) {
+        failures.push({ route, scheme, violation });
+      }
+      await page.close();
+    }
+  }
+
+  await browser.close();
+  server.close();
+
+  for (const { route, scheme, violation } of failures) {
+    console.error(`\n✗ ${route} [${scheme}] — ${violation.id} (${violation.impact})`);
+    console.error(`  ${violation.help}`);
+    console.error(`  ${violation.helpUrl}`);
+    for (const node of violation.nodes.slice(0, 4)) {
+      console.error(`    ${node.target.join(' ')}`);
+      const summary = (node.failureSummary ?? '').split('\n').filter(Boolean).slice(1);
+      for (const line of summary) console.error(`      ${line}`);
+    }
+    if (violation.nodes.length > 4) {
+      console.error(`    … and ${violation.nodes.length - 4} more element(s)`);
+    }
+  }
+
+  if (failures.length) {
+    console.error(
+      `\naxe: ${failures.length} violation(s) across ${checked} page renders (${sampled.length} route shapes × ${SCHEMES.length} colour schemes, sampled from ${routes.length} pages)`,
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `axe: no WCAG 2.1 AA violations in ${checked} page renders (${sampled.length} route shapes × ${SCHEMES.length} colour schemes, sampled from ${routes.length} pages)`,
+  );
+}
+
+await main();


### PR DESCRIPTION
## The defect

axe found **213 contrast failures** on the live dashboard. The palette mixed brand values meant for a light background into a dark-only theme:

| Element | Colours | Ratio | AA |
|---|---|---|---|
| Active filter, primary button | `#ffffff` on `#2F99A4` | 3.37:1 | ✗ |
| Card headings, links | `#2F99A4` on `#1e333a` | 3.90:1 | ✗ |
| Skill pill | `#FF4D00` on `#43261d` | 4.11:1 | ✗ |
| Muted text, tool pill | `#9aa0a6` on `#363a40` | 4.33:1 | ✗ |
| Ansible pill | `#EE0000` on `#40181d` | 3.39:1 | ✗ |
| Links inside prose | 2.8:1 against surrounding text, no underline | | ✗ |

Three new tokens carry the same hues at a passing luminance — `--accent-ink` (`#5CC0CB`) and `--accent-2-ink` (`#FF7A45`) for text on dark, `--accent-fill` (`#1B6C74`) for a fill behind white text. `--fg-muted` moves to `#B4BAC0`. The language pills keep their hue and gain luminance. `--nr-teal` and `--nr-orange` stay the brand values wherever the threshold is 3:1: borders, chart series, icons.

Links in running text are underlined now. `a { text-decoration: none }` left colour as the only cue, and the colour difference to the surrounding copy was 2.8:1 — under the 3:1 that would let colour carry it. Navigation, buttons and pills keep their own affordance.

## Why the existing gate missed it

`verify_site.py` and `check_accessibility.py` check what markup alone decides. Contrast needs resolved CSS and a compositing model, so a page with 213 failures passed.

`scripts/axe-audit.mjs` runs axe-core in Chrome against WCAG 2.1 AA in **both colour schemes**.

## Sampling, stated rather than silent

The site has 322 pages built from four templates. Auditing all of them would add roughly twenty minutes per deploy for no new information — two repository pages differ in their data, not in their colour pairs. So the gate audits one page per route shape and prints what it left out:

```
  / → auditing /
  /de/ → auditing /de/
  /de/repo/*/ → auditing /de/repo/agent-harness-skill/ (119 further page(s) of this shape not audited)
  /de/snapshot/*/ → auditing /de/snapshot/2026-04-21/ (39 further page(s) of this shape not audited)
  /repo/*/ → auditing /repo/agent-harness-skill/ (119 further page(s) of this shape not audited)
  /snapshot/*/ → auditing /snapshot/2026-04-21/ (39 further page(s) of this shape not audited)
axe: no WCAG 2.1 AA violations in 12 page renders (6 route shapes × 2 colour schemes, sampled from 322 pages)
```

## Verification

```
verify_site: 322 pages checked, 0 errors, 1 warnings
pytest:      10 passed
axe:         no WCAG 2.1 AA violations
```

The one warning is local: `latest.json` in the checkout is 73 days old. CI collects fresh metrics before rendering.

`package.json` exists for this gate alone. axe is a JavaScript engine and there is no Python equivalent that evaluates resolved CSS; the dashboard itself is still rendered by `scripts/render_site.py`.