### PR TITLE
fix: use the brand system's dark-theme link colour

### DIFF
--- a/dashboard/assets/styles.css
+++ b/dashboard/assets/styles.css
@@ -3,7 +3,8 @@
  * 4.1:1, both below the 4.5:1 AA asks of body text; white on a #2F99A4 fill is
  * 3.37:1. The *-ink tokens are the same hues lifted to a passing luminance for
  * text on dark, --accent-fill is the same hue darkened for fills that carry
- * white text. --nr-teal and --nr-orange stay the brand values and are used
+ * white text. --accent-ink is the brand system's own dark-theme link colour
+ * (see the netresearch-branding reference), not a value invented here. --nr-teal and --nr-orange stay the brand values and are used
  * where the threshold is 3:1: borders, chart series, icons. */
 :root {
   --nr-teal: #2F99A4;
@@ -17,7 +18,7 @@
   --border: #2a2f38;
   --accent: var(--nr-teal);
   --accent-2: var(--nr-orange);
-  --accent-ink: #5CC0CB;
+  --accent-ink: #5FC6D2;
   --accent-2-ink: #FF7A45;
   --accent-fill: #1B6C74;
 }


### PR DESCRIPTION
The dashboard invented `#5CC0CB` for teal text on dark. The branding reference already carries a verified dark-theme value, `#5FC6D2`, which I only found afterwards while writing netresearch/netresearch-branding-skill#58.

It clears every surface here with more headroom:

| Surface | `#5CC0CB` (invented) | `#5FC6D2` (brand system) |
|---|---|---|
| `#363a40` lifted row | 5.37:1 | 5.72:1 |
| `#22262e` card | 7.12:1 | 7.58:1 |
| `#1a1d23` surface | — | 8.44:1 |

## Verification

```
verify_site: 322 pages checked, 0 errors, 1 warnings
axe:         no WCAG 2.1 AA violations in 12 page renders (6 route shapes × 2 colour schemes)
pytest:      10 passed
```

The one warning is local — `latest.json` in the checkout is stale. CI collects fresh metrics before rendering.