### PR TITLE
fix(star-notifications): warn instead of fail on the designed rate-limit give-up

### DIFF
--- a/scripts/check-stars.py
+++ b/scripts/check-stars.py
@@ -78,9 +78,22 @@ class RateLimitError(Exception):
     systemic rather than per-repo, so the per-repo fetchers must not catch it
     and carry on walking the remaining repos — every one of them would hit the
     same wall, and the run would end up reporting a few hundred bogus
-    "inaccessible" repos instead of the one real cause. It propagates to main()
-    and turns the run red with a message that names the limit and its reset.
+    "inaccessible" repos instead of the one real cause. It propagates out of
+    main() with a message that names the limit and its reset.
+
+    `deferred_to_next_run` marks the DESIGNED give-up: the primary hourly
+    budget is spent and the wait to its documented reset exceeds what is left
+    of this run's sleep budget. The schedule is the outer retry loop (see
+    RATE_LIMIT_TOTAL_BUDGET), the reset is at most an hour out, and no state
+    has been saved yet, so handing over to a successor is the intended
+    behaviour — run() turns it into a ::warning:: and exit 0. Every other
+    give-up (a secondary limit mid-processing, retries exhausted) stays False
+    and turns the run red.
     """
+
+    def __init__(self, message: str, *, deferred_to_next_run: bool = False):
+        super().__init__(message)
+        self.deferred_to_next_run = deferred_to_next_run
 
 
 def is_rate_limited(response: requests.Response) -> bool:
@@ -222,10 +235,16 @@ def github_request(url: str, accept: str = "application/vnd.github+json", max_re
                         # Sleeping a partial wait would just burn an attempt on a
                         # request that is certain to be refused, so stop here and
                         # let the next scheduled run try with a fresh budget.
+                        # Deferring is only safe for a PRIMARY limit (zeroed
+                        # budget header, same test describe_rate_limit uses):
+                        # its reset is documented and at most an hour out, so a
+                        # successor run is guaranteed fresh quota. A secondary
+                        # limit that outlasted 600s of backoff is abuse
+                        # detection with no promised end — that stays a failure.
                         raise RateLimitError(describe_rate_limit(
                             url, response, rate_limit_attempt,
                             f"the next wait of {wait:.0f}s exceeds the {budget_left:.0f}s left in the budget",
-                        ))
+                        ), deferred_to_next_run=response.headers.get("X-RateLimit-Remaining") == "0")
                     rate_limit_attempt += 1
                     spend_rate_limit_budget(wait)
                     # Flushed because stdout is block-buffered under Actions: an
@@ -702,18 +721,39 @@ def main():
             print(f"  - {name}: {reason}")
 
 
-if __name__ == "__main__":
+def run() -> int:
+    """Process exit code for main(), separating designed hand-overs from failures.
+
+    The deferred give-up (primary budget spent, wait to reset exceeds the
+    per-run sleep budget) is the script doing exactly what its comments
+    promise, so it must not produce a red run — a red run for a non-actionable,
+    self-healing condition trains people to ignore red runs. It exits 0 with a
+    ::warning:: carrying the same diagnostic text. Safe because the give-up
+    raises out of the repo loop BEFORE any notification is sent and before
+    save_state(), so the state file on disk is still the downloaded previous
+    state and re-uploading it is a no-op — nothing is advanced or lost.
+
+    Every other rate-limit give-up stays red: a secondary limit that outlasts
+    the budget mid-processing is abuse detection with no documented reset, and
+    exhausting all retries means waits that FIT the budget never cleared the
+    limit. A run of red ones means the token's hourly budget is genuinely too
+    small for ~280 repos at this cadence, and the cadence or the request count
+    has to give.
+    """
     try:
         main()
     except RateLimitError as e:
-        # Still red — a rate limit that outlasts the whole budget is worth
-        # noticing — but red for a stated reason. The schedule fires every 15
-        # minutes, so one occurrence is normally self-healing; a run of them
-        # means the token's hourly budget is genuinely too small for ~280 repos
-        # at this cadence, and the cadence or the request count has to give.
+        if e.deferred_to_next_run:
+            print(f"::warning::{e} Working as designed: the next scheduled run retries with a fresh budget.")
+            return 0
         print(f"::error::{e} The next scheduled run retries with a fresh budget.")
-        raise SystemExit(1)
+        return 1
     except AuthError as e:
         print(f"::error::{e}. Check that STAR_NOTIFICATIONS_PAT is set, unexpired, and grants "
               f"Metadata: read on the {ORG_NAME} org.")
-        raise SystemExit(1)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/tests/test_check_stars.py
+++ b/tests/test_check_stars.py
@@ -223,6 +223,75 @@ def test_rate_limit_give_up_message_names_the_cause():
     assert "403 Client Error: Forbidden" not in message, "the bare HTTPError text is what this replaces"
 
 
+def _run_with_main_raising(exc):
+    """Call run() with main() replaced by one that raises `exc`.
+
+    Returns (exit_code, captured_stdout).
+    """
+    import contextlib
+    import io
+
+    def _raise():
+        raise exc
+
+    original_main = check_stars.main
+    check_stars.main = _raise  # type: ignore[assignment]
+    out = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(out):
+            code = check_stars.run()
+    finally:
+        check_stars.main = original_main  # type: ignore[assignment]
+    return code, out.getvalue()
+
+
+def test_primary_budget_give_up_is_deferred_and_exits_zero():
+    """Reproduces run 13078 (2026-08-13T21:28): primary budget spent, reset 1523s
+    away, further than the 600s left in the per-run budget.
+
+    The give-up is the DESIGNED hand-over to the next scheduled run, so it must
+    mark the error as deferred, never sleep a partial wait, and run() must turn
+    it into a ::warning:: with exit 0 instead of a red run.
+    """
+    reset_at = int(check_stars.time.time()) + 1523
+    response = _FakeResponse(headers={"X-RateLimit-Remaining": "0", "X-RateLimit-Limit": "5000",
+                                      "X-RateLimit-Reset": str(reset_at)})
+    raised, slept = _drive_rate_limited_request(response)
+
+    assert isinstance(raised, check_stars.RateLimitError), f"expected RateLimitError, got {raised!r}"
+    assert raised.deferred_to_next_run is True, "a primary budget give-up must defer to the next run"
+    assert slept == [], f"a wait that exceeds the budget must not be slept at all, slept {slept}"
+
+    code, out = _run_with_main_raising(raised)
+    assert code == 0, f"a deferred give-up must exit 0, got {code}"
+    assert "::warning::" in out, f"the deferred give-up must still annotate the run, got: {out}"
+    assert "::error::" not in out
+    assert str(raised) in out, "the warning must carry the full diagnostic text"
+
+
+def test_secondary_budget_give_up_still_fails():
+    """A secondary limit that outlasts the budget is abuse detection with no
+    documented reset — it must NOT be deferred, and run() must stay red."""
+    response = _FakeResponse(text="You have exceeded a secondary rate limit. Please wait a few minutes")
+    raised, _ = _drive_rate_limited_request(response)
+
+    assert isinstance(raised, check_stars.RateLimitError), f"expected RateLimitError, got {raised!r}"
+    assert raised.deferred_to_next_run is False, "a secondary-limit give-up must not defer"
+
+    code, out = _run_with_main_raising(raised)
+    assert code == 1, f"a secondary-limit give-up must exit 1, got {code}"
+    assert "::error::" in out
+
+    # The retries-exhausted give-up constructs RateLimitError without the flag,
+    # so the default must be "red" — guard it here.
+    assert check_stars.RateLimitError("x").deferred_to_next_run is False
+
+    # AuthError handling is unchanged: still red.
+    code, out = _run_with_main_raising(check_stars.AuthError("no token in the environment"))
+    assert code == 1, f"an AuthError must exit 1, got {code}"
+    assert "::error::" in out
+
+
 def test_permission_403_is_still_an_autherror():
     """Guard the split: only a rate-limit 403 gets the patient treatment.
 
@@ -256,5 +325,9 @@ if __name__ == "__main__":
     print("OK: secondary limit waits minutes, bounded by the budget")
     test_rate_limit_give_up_message_names_the_cause()
     print("OK: give-up message names the rate limit and its reset")
+    test_primary_budget_give_up_is_deferred_and_exits_zero()
+    print("OK: primary budget give-up warns and exits 0")
+    test_secondary_budget_give_up_still_fails()
+    print("OK: secondary budget give-up still fails red")
     test_permission_403_is_still_an_autherror()
     print("OK: permission 403 is still an AuthError")


### PR DESCRIPTION
## Problem

[Star Notifications run 13078](https://github.com/netresearch/maint/actions/runs/31745775396) (2026-08-13 21:28 UTC) exited 1 with `GitHub primary rate limit still in effect after 0 attempt(s) — the next wait of 1523s exceeds the 600s left in the budget … The next scheduled run retries with a fresh budget.` That is the script's DESIGNED give-up: the per-run sleep budget (`RATE_LIMIT_TOTAL_BUDGET = 600`) exists precisely so that a run which cannot get through hands over to its successor, because the schedule is the outer retry loop. The quota exhaustion was external — a fleet release sweep the same evening drained the shared PAT's primary hourly quota (documented in [netresearch/skill-repo-skill@f4e54bac](https://github.com/netresearch/skill-repo-skill/commit/f4e54bac)) — and every subsequent scheduled run succeeded. Reporting the designed hand-over as a FAILED run produces a red-run notification for a non-actionable, self-healing condition, which trains people to ignore red runs on this workflow.

## Change

`RateLimitError` gains a `deferred_to_next_run` flag, set at exactly one raise site: the budget give-up (`wait > budget_left`) when the limit is the PRIMARY one (`X-RateLimit-Remaining: 0`, the same test `describe_rate_limit` uses to call it "primary"). A new `run()` wrapper (the former `__main__` block, made testable) turns that case into a `::warning::` annotation carrying the same diagnostic text and exits 0. Every other error path fails exactly as before: a SECONDARY limit that outlasts the budget mid-processing is abuse detection with no documented reset and stays red (this is also the few-line anti-starvation guard — warn-vs-fail keyed on the kind of limit); the retries-exhausted give-up constructs the error without the flag, so it defaults to red (guarded by a test); `AuthError` handling is unchanged.

## Why the early give-up cannot corrupt state

`RateLimitError` propagates out of the repo loop before any Matrix notification is sent (notifications are queued and sent only after the loop) and before `save_state()` runs, so `state/stars-state.json` on disk is still the previously downloaded artifact. The only behavioural difference in the workflow is that the `Upload updated state` step now runs (the job succeeds) and re-uploads that unchanged file with `overwrite: true` — a content no-op that merely refreshes the artifact's 90-day retention. Nothing is advanced, so the next run re-detects the same events with no duplicates possible (none were sent).

## Considered and rejected: warn only when the reset falls before the next scheduled run

The suggestion of keying warn-vs-fail on "reset before the next scheduled run" would have kept the triggering run RED: its reset was 29 minutes out while the schedule fires every 15 minutes, yet the condition still self-healed within the hour because the primary window resets hourly by construction. A primary reset is always at most an hour out, so some successor run always gets fresh quota; the only true permanent-starvation case is an external consumer draining the quota every hour indefinitely, which a single run cannot observe. Detecting THAT would need give-up counting across runs (state in the artifact) — noted as a possible follow-up, deliberately not built here.

## The "Skipping <repo> (stargazers): 403 Resource not accessible by personal access token" lines

Those are the intentional, already-handled per-repo skip path: `get_stargazers`/`get_forks`/`get_watchers` catch `AuthError`, record the repo in `_inaccessible`, and `main()` summarises them in a `::warning::` at the end — untouched by this PR.

## Tests

Extended `tests/test_check_stars.py` (12 pass locally): the deferred give-up reproducing run 13078's headers (primary limit, reset 1523s out) yields `deferred_to_next_run=True`, sleeps nothing, and `run()` returns 0 with `::warning::` and the full diagnostic; the secondary-limit give-up yields `deferred_to_next_run=False` and `run()` returns 1 with `::error::`; the flag defaults to False for the retries-exhausted raise; `AuthError` still exits 1. A defect-injection check (forcing the flag to False at the raise site) makes the new test fail, so it guards the exact position. CI DOES execute this suite: [tests.yml](https://github.com/netresearch/maint/blob/main/.github/workflows/tests.yml) runs `pytest tests/ -v` on every pull request and on push to main.

https://claude.ai/code/session_01AcqcEjgwcQfp3vpnFa3gh6
