### PR TITLE
fix(star-notifications): fail after 5 consecutive rate-limit hand-overs

### DIFF
--- a/.github/workflows/star-notifications.yml
+++ b/.github/workflows/star-notifications.yml
@@ -44,6 +44,15 @@ jobs:
         run: python scripts/check-stars.py
 
       - name: Upload updated state
+        # Also on a failed run, because the state file carries the cross-run
+        # count of consecutive rate-limit hand-overs, and the run that trips the
+        # threshold is red by design — with the default `success()` that count
+        # would be the one thing never persisted, freezing the streak one below
+        # the threshold and understating it in every later error message. Safe
+        # because a failed run never reaches save_state(): the file it uploads
+        # is the downloaded one plus that counter. Cancellation is excluded, as
+        # it can land mid-write and upload a truncated file.
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: stars-state

--- a/scripts/check-stars.py
+++ b/scripts/check-stars.py
@@ -40,6 +40,23 @@ SECONDARY_RATE_LIMIT_WAIT = 60
 RATE_LIMIT_TOTAL_BUDGET = 600
 _rate_limit_slept = 0.0
 
+# --- Chronic starvation ------------------------------------------------------
+# A deferred give-up (see RateLimitError) ends the run green, which is right for
+# an hour whose budget someone else drained. It is wrong for a token that is
+# permanently starved: every run would hand over to a successor that hands over
+# again, forever green, processing zero repos, with only a ::warning:: nobody
+# reads. So consecutive deferrals are counted across runs, and the streak turns
+# the run red once it can no longer be explained by a single bad hour.
+#
+# The number comes from the two cadences involved: the workflow runs every 15
+# minutes (4 runs/hour) and the primary budget resets hourly. Four deferrals in
+# a row span only 45 minutes and can therefore all sit inside ONE drained hour —
+# exactly the case that must stay green. The fifth is at least 60 minutes after
+# the first, so at least one full hourly reset has come and gone without giving
+# this token enough budget to finish a run: no longer a bad hour, a bad setup.
+DEFERRED_GIVEUP_STREAK_KEY = "deferred_giveup_streak"
+MAX_CONSECUTIVE_DEFERRALS = 5
+
 # In-memory cache for user details (login -> user info dict)
 _user_cache: dict[str, dict] = {}
 
@@ -528,11 +545,44 @@ def load_state() -> dict:
     return {"repos": {}, "last_run": None}
 
 
-def save_state(state: dict) -> None:
-    """Save current state to file."""
+def write_state(state: dict) -> None:
+    """Write the state file verbatim, without interpreting what is in it."""
     STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
-    state["last_run"] = datetime.utcnow().isoformat()
     STATE_FILE.write_text(json.dumps(state, indent=2))
+
+
+def save_state(state: dict) -> None:
+    """Save the state of a COMPLETED run.
+
+    Called from the tail of main() only, i.e. once every repo has been walked,
+    which is also the definition of a run that did not give up — so this is
+    where the deferral streak is cleared. Do not call it mid-loop: that would
+    both stamp a last_run for a run that never finished and forgive a streak
+    that is still going.
+    """
+    state["last_run"] = datetime.utcnow().isoformat()
+    state[DEFERRED_GIVEUP_STREAK_KEY] = 0
+    write_state(state)
+
+
+def bump_deferred_giveup_streak() -> int:
+    """Count this deferred give-up against the previous ones, and return the streak.
+
+    Deliberately re-reads the file instead of taking main()'s in-memory state:
+    by the time a give-up raises, that dict already holds fresh social data for
+    the repos walked before the limit hit, and writing it would advance their
+    seen-stars sets without the run having notified anything for the repos it
+    never reached. Round-tripping the file touches the counter and nothing else,
+    so the seen-stars data stays exactly as the previous run left it. For the
+    same reason this must not go through save_state(), which stamps last_run —
+    on a first-ever run that would suppress the first-run indexing and turn
+    every existing stargazer into a "new" notification on the next run.
+    """
+    state = load_state()
+    streak = state.get(DEFERRED_GIVEUP_STREAK_KEY, 0) + 1
+    state[DEFERRED_GIVEUP_STREAK_KEY] = streak
+    write_state(state)
+    return streak
 
 
 def notify_matrix(message: str) -> None:
@@ -731,7 +781,8 @@ def run() -> int:
     ::warning:: carrying the same diagnostic text. Safe because the give-up
     raises out of the repo loop BEFORE any notification is sent and before
     save_state(), so the state file on disk is still the downloaded previous
-    state and re-uploading it is a no-op — nothing is advanced or lost.
+    state — bar the deferral counter below, which is written on its own — and
+    re-uploading it advances no seen-stars data.
 
     Every other rate-limit give-up stays red: a secondary limit that outlasts
     the budget mid-processing is abuse detection with no documented reset, and
@@ -739,12 +790,27 @@ def run() -> int:
     limit. A run of red ones means the token's hourly budget is genuinely too
     small for ~280 repos at this cadence, and the cadence or the request count
     has to give.
+
+    A green hand-over is only sound while there is a successor that can do the
+    work, so deferrals are counted across runs and the MAX_CONSECUTIVE_DEFERRALS
+    one turns red anyway: at that point the hand-over has been going on longer
+    than a single hourly reset, and permanent quota starvation must not hide
+    behind an endless row of green runs that process nothing.
     """
     try:
         main()
     except RateLimitError as e:
         if e.deferred_to_next_run:
-            print(f"::warning::{e} Working as designed: the next scheduled run retries with a fresh budget.")
+            streak = bump_deferred_giveup_streak()
+            if streak >= MAX_CONSECUTIVE_DEFERRALS:
+                print(f"::error::{e} This is give-up {streak} in a row, spanning more than the hourly "
+                      f"primary-limit reset, so no run in over an hour has processed a single repo. "
+                      f"The token's budget is not momentarily drained, it is too small for this "
+                      f"cadence — reduce the schedule or the request count.")
+                return 1
+            print(f"::warning::{e} Working as designed: the next scheduled run retries with a fresh "
+                  f"budget (consecutive deferral {streak} of {MAX_CONSECUTIVE_DEFERRALS} before this "
+                  f"turns red).")
             return 0
         print(f"::error::{e} The next scheduled run retries with a fresh budget.")
         return 1

--- a/tests/test_check_stars.py
+++ b/tests/test_check_stars.py
@@ -4,8 +4,11 @@
 Runnable standalone (`python tests/test_check_stars.py`) or via pytest.
 """
 
+import contextlib
 import importlib.util
+import json
 import os
+import tempfile
 from pathlib import Path
 
 # The module reads MATRIX_WEBHOOK_URL at import time; provide a dummy value.
@@ -292,6 +295,107 @@ def test_secondary_budget_give_up_still_fails():
     assert "::error::" in out
 
 
+@contextlib.contextmanager
+def _temp_state(initial):
+    """Point the module's STATE_FILE at a throwaway file holding `initial`.
+
+    Yields the path so a test can read back what the code under test wrote.
+    """
+    original = check_stars.STATE_FILE
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "state" / "stars-state.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(initial))
+        check_stars.STATE_FILE = path  # type: ignore[assignment]
+        try:
+            yield path
+        finally:
+            check_stars.STATE_FILE = original  # type: ignore[assignment]
+
+
+def _defer_once(seeded_state):
+    """Drive run() through one deferred give-up against `seeded_state`.
+
+    Returns (exit_code, stdout, state_as_written_back).
+    """
+    deferred = check_stars.RateLimitError(
+        "GitHub primary rate limit still in effect after 0 attempt(s)",
+        deferred_to_next_run=True,
+    )
+    with _temp_state(seeded_state) as path:
+        code, out = _run_with_main_raising(deferred)
+        return code, out, json.loads(path.read_text())
+
+
+def test_deferred_give_up_counts_up_without_touching_the_seen_stars():
+    """A hand-over must record that it happened and change nothing else.
+
+    The whole safety argument for exiting 0 is that the give-up raises before
+    save_state(), so the downloaded seen-stars data is re-uploaded untouched.
+    Counting the deferral writes to that same file, so this pins both halves:
+    the counter goes up, and the repos/last_run it shares the file with come
+    back byte-identical.
+    """
+    seeded = {
+        "repos": {"netresearch/foo": {"stars": ["alice"], "forks": [], "watchers": [], "dependents": []}},
+        "last_run": "2026-08-14T21:00:00",
+    }
+    code, out, stored = _defer_once(seeded)
+
+    assert code == 0, f"a deferred give-up below the threshold must still exit 0, got {code}"
+    assert "::warning::" in out and "::error::" not in out, f"expected a warning, got: {out}"
+    assert stored[check_stars.DEFERRED_GIVEUP_STREAK_KEY] == 1, \
+        f"first deferral must count as 1, got {stored.get(check_stars.DEFERRED_GIVEUP_STREAK_KEY)!r}"
+    assert stored["repos"] == seeded["repos"], "the give-up path must not advance the seen-stars data"
+    assert stored["last_run"] == seeded["last_run"], \
+        "the give-up path must not stamp last_run — that would suppress a pending first-run indexing"
+
+
+def test_streak_reaching_the_threshold_turns_the_run_red():
+    """Permanent starvation must stop hiding behind green runs.
+
+    One below the threshold is still the designed hand-over; the run that
+    reaches it has been deferring for longer than the hourly primary reset, so
+    it goes red with the streak named in the message.
+    """
+    below = {"repos": {}, "last_run": "2026-08-14T21:00:00",
+             check_stars.DEFERRED_GIVEUP_STREAK_KEY: check_stars.MAX_CONSECUTIVE_DEFERRALS - 2}
+    code, out, stored = _defer_once(below)
+    assert code == 0, f"deferral {check_stars.MAX_CONSECUTIVE_DEFERRALS - 1} must stay green, got {code}"
+    assert "::warning::" in out and "::error::" not in out
+    assert stored[check_stars.DEFERRED_GIVEUP_STREAK_KEY] == check_stars.MAX_CONSECUTIVE_DEFERRALS - 1
+
+    at_threshold = dict(below)
+    at_threshold[check_stars.DEFERRED_GIVEUP_STREAK_KEY] = check_stars.MAX_CONSECUTIVE_DEFERRALS - 1
+    code, out, stored = _defer_once(at_threshold)
+    assert code == 1, f"deferral {check_stars.MAX_CONSECUTIVE_DEFERRALS} must fail the run, got {code}"
+    assert "::error::" in out and "::warning::" not in out, f"expected an error annotation, got: {out}"
+    assert f"{check_stars.MAX_CONSECUTIVE_DEFERRALS} in a row" in out, \
+        f"the error must name the streak so the log says why it is red now; got: {out}"
+    assert stored[check_stars.DEFERRED_GIVEUP_STREAK_KEY] == check_stars.MAX_CONSECUTIVE_DEFERRALS, \
+        "the red run must still persist its count, or the streak freezes one below the threshold"
+
+
+def test_a_completed_run_resets_the_streak():
+    """save_state() is the tail of main(), so reaching it clears the streak.
+
+    Without the reset, five deferrals spread over a week of otherwise healthy
+    runs would eventually turn a run red for a limit that has long since lifted.
+    """
+    seeded = {"repos": {}, "last_run": None,
+              check_stars.DEFERRED_GIVEUP_STREAK_KEY: check_stars.MAX_CONSECUTIVE_DEFERRALS - 1}
+    with _temp_state(seeded) as path:
+        state = check_stars.load_state()
+        assert state[check_stars.DEFERRED_GIVEUP_STREAK_KEY] == check_stars.MAX_CONSECUTIVE_DEFERRALS - 1, \
+            "precondition: the streak must survive the load it is meant to be reset from"
+        check_stars.save_state(state)
+        stored = json.loads(path.read_text())
+
+    assert stored[check_stars.DEFERRED_GIVEUP_STREAK_KEY] == 0, \
+        f"a completed run must clear the streak, got {stored[check_stars.DEFERRED_GIVEUP_STREAK_KEY]!r}"
+    assert stored["last_run"], "save_state must still stamp the completion time"
+
+
 def test_permission_403_is_still_an_autherror():
     """Guard the split: only a rate-limit 403 gets the patient treatment.
 
@@ -329,5 +433,11 @@ if __name__ == "__main__":
     print("OK: primary budget give-up warns and exits 0")
     test_secondary_budget_give_up_still_fails()
     print("OK: secondary budget give-up still fails red")
+    test_deferred_give_up_counts_up_without_touching_the_seen_stars()
+    print("OK: deferred give-up counts up and leaves the seen stars alone")
+    test_streak_reaching_the_threshold_turns_the_run_red()
+    print("OK: the streak turns the run red at the threshold")
+    test_a_completed_run_resets_the_streak()
+    print("OK: a completed run resets the streak")
     test_permission_403_is_still_an_autherror()
     print("OK: permission 403 is still an AuthError")


### PR DESCRIPTION
Follow-up to [#52](https://github.com/netresearch/maint/pull/52), which made the designed rate-limit give-up end the run green with a `::warning::` instead of red. That is the right call for one hour whose primary quota someone else drained — the reset is at most an hour out, the schedule is the outer retry loop, and no state has been advanced. It is the wrong call for a token that is permanently starved: every run would hand over to a successor that hands over again, forever green, processing zero repos, with only a warning nobody reads to say so.

This counts consecutive deferrals across runs and turns the run red again once the streak can no longer be explained by a single bad hour: the fifth give-up in a row exits 1 with an `::error::` that names the streak and says what to do about it (reduce the schedule or the request count). Any run that completes `main()` resets the counter to 0, so a stray deferral now and then never accumulates into a false alarm.

**Why five.** The two cadences involved are the workflow schedule (`*/15 * * * *`, four runs an hour) and the primary quota, which resets hourly. Four deferrals in a row span only 45 minutes and can therefore all sit inside ONE drained hour — exactly the case #52 wants green. The fifth is at least 60 minutes after the first, so at least one full hourly reset has come and gone without giving this token enough budget to finish a run. That is no longer a bad hour, it is a bad setup. The reasoning sits in a comment at the constant.

**Where the counter lives, and why the seen-stars data is safe.** It is a dedicated top-level `deferred_giveup_streak` key in the same `state/stars-state.json` that the workflow downloads and uploads as an artifact — no second artifact, no second mechanism. The load-bearing property #52 established is that a deferred give-up raises before `save_state()`, leaving the downloaded seen-stars data untouched; the counter must not weaken that, so it is written by its own `bump_deferred_giveup_streak()` which re-reads the file from disk instead of reusing `main()`'s in-memory `state`. That dict is not a safe thing to write: by the time the give-up raises, it already holds fresh social data for the repos walked before the limit hit, and persisting it would advance their seen-stars sets for repos whose notifications the run never got to send. For the same reason the bump bypasses `save_state()` and goes through a new raw `write_state()` — `save_state()` stamps `last_run`, and on a first-ever run that would suppress the pending first-run indexing and turn every existing stargazer into a "new" notification on the next run. `test_deferred_give_up_counts_up_without_touching_the_seen_stars` asserts both halves: the counter goes up, and `repos` plus `last_run` come back unchanged.

**Where the reset lives.** In `save_state()`, which is called only from the tail of `main()` — reaching it *is* the definition of a run that walked every repo and did not give up. A red run for any other reason (secondary limit mid-processing, retries exhausted, `AuthError`) touches the counter in neither direction: it never reaches `save_state()` and it is not the deferred branch, so the streak is carried forward as loaded.

**One workflow change was needed.** `Upload updated state` had no `if:`, so it ran under the implicit `success()`. On the deferred path that is fine — the script exits 0 and the counter is uploaded — but the run that trips the threshold is red *by design*, and would have been the one run whose count never persisted, freezing the stored streak one below the threshold and understating it in every later error message. It now runs on `!cancelled()`. That is safe because a failed run never reaches `save_state()`, so the file it uploads is the downloaded state plus the counter; cancellation stays excluded because it can land mid-write and upload a truncated file.

## Verification

Full suite, on the committed tree, with the pinned test requirements (`uv pip install --only-binary :all: --require-hashes -r requirements/tests.txt`), which is what `tests.yml` runs:

```
$ pytest tests/ -q
15 passed, 1 warning in 0.13s
```

The warning is pre-existing: `datetime.utcnow()` in `save_state()` is deprecated in 3.14, and the new reset test is simply the first to call that function. Left alone rather than folded into this change.

The standalone entry point (`python tests/test_check_stars.py`) also runs all fifteen and prints OK for each.

Defect injection, each probe checked in the position the new assertion sits:

| Probe | Expected to fail | Result |
| --- | --- | --- |
| Remove `state[DEFERRED_GIVEUP_STREAK_KEY] = 0` from `save_state()` | the reset test | `1 failed, 14 passed` — `test_a_completed_run_resets_the_streak` |
| `streak >= MAX_CONSECUTIVE_DEFERRALS` weakened to `>` | the threshold test | `1 failed, 14 passed` — `test_streak_reaching_the_threshold_turns_the_run_red` |
| Bump writes through `save_state()` instead of `write_state()` | the seen-stars/`last_run` assertions | `2 failed, 13 passed` — the counting test and the threshold test |

Each probe was reverted from a backup and the suite re-run green before committing.
